### PR TITLE
Add OpenCode workflows for PR reviews and on-demand /oc tasks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# CodeRabbit is not used in this repo — OpenCode handles PR reviews
+# (.github/workflows/opencode-review.yml). Keep auto-review off so the two
+# bots don't duplicate reviews or push to each other's branches.
+reviews:
+  auto_review:
+    enabled: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,0 @@
-# CodeRabbit is not used in this repo — OpenCode handles PR reviews
-# (.github/workflows/opencode-review.yml). Keep auto-review off so the two
-# bots don't duplicate reviews or push to each other's branches.
-reviews:
-  auto_review:
-    enabled: false

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           persist-credentials: false
           submodules: recursive
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,9 +1,12 @@
 name: opencode-review
 
 # Automatic PR reviews via OpenCode.
-# Triggers on every PR (opened, updated, reopened, or marked ready for review).
+# Triggers on every non-draft PR (opened, updated, reopened, or marked
+# ready for review). Skips drafts to avoid reviewing WIPs.
 # To re-run / request a review manually, comment `/oc review` on the PR
 # (handled by opencode.yml).
+
+permissions: {}
 
 on:
   pull_request:
@@ -11,7 +14,12 @@ on:
 
 jobs:
   review:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: opencode-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write
@@ -20,6 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          submodules: recursive
 
       - uses: anomalyco/opencode/github@latest
         env:

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -14,7 +14,9 @@ on:
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
+    # Bots (dependabot, coderabbit, ...) lack the write permission the action
+    # requires, so skip their pushes instead of failing the run.
+    if: github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -73,16 +75,18 @@ jobs:
             Posting (CodeRabbit-style inline comments):
             - Submit ALL findings as ONE GitHub review so they appear inline on the
               code, using the gh CLI (GITHUB_TOKEN is in your environment):
-              1. Get context: PR_NUMBER and HEAD_SHA via
-                 `gh pr view $PR --json number,headRefOid` (PR number is also in
-                 $GITHUB_EVENT_PATH), repo slug from $GITHUB_REPOSITORY.
-              2. POST the review:
-                 gh api repos/<owner>/<repo>/pulls/<pr>/reviews --method POST \
-                   -f commit_id=<HEAD_SHA> -f event=COMMENT \
-                   -f body="<summary + walkthrough table + verdict>" \
-                   -f comments='<JSON array of {"path","line","side":"RIGHT","body"}>'
-                 One array entry per finding; body = severity + title + explanation + fix.
-                 Only comment on lines that are part of the PR diff.
+              1. Get context: repo slug from $GITHUB_REPOSITORY; PR number and head SHA
+                 via `gh pr view <number> --json number,headRefOid`
+                 (the number is also in $GITHUB_EVENT_PATH).
+              2. Write the review payload to /tmp/review.json using a heredoc —
+                 do NOT inline JSON in shell arguments:
+                 {"commit_id":"<HEAD_SHA>","event":"COMMENT",
+                  "body":"<summary + walkthrough table + verdict>",
+                  "comments":[{"path":"...","line":N,"side":"RIGHT",
+                               "body":"<severity + title + explanation + fix>"}, ...]}
+                 One entry per finding. Only comment on lines in the PR diff.
+              3. Post it:
+                 gh api repos/<owner>/<repo>/pulls/<pr>/reviews --method POST --input /tmp/review.json
               3. Keep your final chat message to ONE line ("Inline review posted."),
                  because the harness posts it as a separate top-level PR comment.
             - If the API call fails (e.g. 403 on fork PRs where the token is

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -69,3 +69,22 @@ jobs:
             misuse, error handling and edge cases.
 
             End with one line: **Verdict:** APPROVE | REQUEST CHANGES | COMMENT
+
+            Posting (CodeRabbit-style inline comments):
+            - Submit ALL findings as ONE GitHub review so they appear inline on the
+              code, using the gh CLI (GITHUB_TOKEN is in your environment):
+              1. Get context: PR_NUMBER and HEAD_SHA via
+                 `gh pr view $PR --json number,headRefOid` (PR number is also in
+                 $GITHUB_EVENT_PATH), repo slug from $GITHUB_REPOSITORY.
+              2. POST the review:
+                 gh api repos/<owner>/<repo>/pulls/<pr>/reviews --method POST \
+                   -f commit_id=<HEAD_SHA> -f event=COMMENT \
+                   -f body="<summary + walkthrough table + verdict>" \
+                   -f comments='<JSON array of {"path","line","side":"RIGHT","body"}>'
+                 One array entry per finding; body = severity + title + explanation + fix.
+                 Only comment on lines that are part of the PR diff.
+              3. Keep your final chat message to ONE line ("Inline review posted."),
+                 because the harness posts it as a separate top-level PR comment.
+            - If the API call fails (e.g. 403 on fork PRs where the token is
+              read-only), fall back to putting the full CodeRabbit-formatted review
+              in your final message instead.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -16,7 +16,7 @@ jobs:
   review:
     # Bots (dependabot, coderabbit, ...) lack the write permission the action
     # requires, so skip their pushes instead of failing the run.
-    if: github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]') && github.actor != 'coderabbitai'
+    if: github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]') && github.actor != 'coderabbitai' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -27,13 +27,13 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
           submodules: recursive
 
-      - uses: anomalyco/opencode/github@latest
+      - uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a # latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,37 @@
+name: opencode-review
+
+# Automatic PR reviews via OpenCode.
+# Triggers on every PR (opened, updated, reopened, or marked ready for review).
+# To re-run / request a review manually, comment `/oc review` on the PR
+# (handled by opencode.yml).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode/muse-spark-1.3-contributor-free
+          use_github_token: true
+          prompt: |
+            Review this pull request:
+            - Check for code quality issues
+            - Look for potential bugs (esp. Rust panics/unwraps, TS type errors, Tauri command misuse)
+            - Check error handling and edge cases
+            - Suggest concrete improvements with file/line references
+            - Keep the review concise; skip praise, focus on actionable findings

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -16,7 +16,7 @@ jobs:
   review:
     # Bots (dependabot, coderabbit, ...) lack the write permission the action
     # requires, so skip their pushes instead of failing the run.
-    if: github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]')
+    if: github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]') && github.actor != 'coderabbitai'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -41,54 +41,67 @@ jobs:
           model: opencode/muse-spark-1.3-contributor-free
           use_github_token: true
           prompt: |
-            Review this pull request. Format your review EXACTLY like CodeRabbit:
+            Review this pull request. Format your final response EXACTLY like CodeRabbit with collapsible sections:
 
-            ## Review — PR #<number>
-            <one-paragraph walkthrough of what the PR does>
+            ## 🤖 Review — PR #<number>
+            <one-paragraph executive summary of the changes>
 
-            ### Walkthrough
-            A per-file summary table:
+            <details>
+            <summary><b>📖 Changes Walkthrough</b></summary>
+
             | File(s) | Summary |
             |---|---|
-            | ... | ... |
+            | `path/to/file` | Brief functional summary |
 
-            If the change involves runtime interactions, data flow, or multi-step processes,
-            include a ```mermaid sequence diagram. Omit it for trivial diffs.
+            <if non-trivial runtime interaction, state flow, or architecture changes exist, include a ```mermaid sequence diagram here>
 
-            ### Findings
-            Numbered, most severe first. Each finding uses this shape:
-            #### <Severity>: <short title> — `path/to/file:start-end`
-            <why it matters>
+            </details>
+
+            <details open>
+            <summary><b>🎯 Review Findings</b></summary>
+
+            Numbered, most severe first. Each finding uses this format:
+            #### <Severity>: <short title> — `path/to/file:line`
+            <why it matters / root cause explanation>
             Fix:
             ```<lang>
-            <concrete code>
+            <concrete code fix>
             ```
-            Severities: High (bug / security / data loss), Medium (correctness /
-            robustness / perf), Low (nit). Only actionable findings with file/line
-            references. No praise, no generic advice. Skip categories with no findings.
+            Severities: High (bug / security / data loss), Medium (correctness / robustness / perf), Low (nit / readability).
+            Only actionable findings with concrete file/line references. No generic advice or compliments.
+            If no issues are found, state: "No major issues identified."
 
-            Focus areas for this repo: Rust panics/unwraps, TS type errors, Tauri command
-            misuse, error handling and edge cases.
+            </details>
 
-            End with one line: **Verdict:** APPROVE | REQUEST CHANGES | COMMENT
+            <details>
+            <summary><b>ℹ️ Review Info & Verdict</b></summary>
 
-            Posting (CodeRabbit-style inline comments):
-            - Submit ALL findings as ONE GitHub review so they appear inline on the
-              code, using the gh CLI (GITHUB_TOKEN is in your environment):
-              1. Get context: repo slug from $GITHUB_REPOSITORY; PR number and head SHA
-                 via `gh pr view <number> --json number,headRefOid`
-                 (the number is also in $GITHUB_EVENT_PATH).
-              2. Write the review payload to /tmp/review.json using a heredoc —
-                 do NOT inline JSON in shell arguments:
-                 {"commit_id":"<HEAD_SHA>","event":"COMMENT",
-                  "body":"<summary + walkthrough table + verdict>",
-                  "comments":[{"path":"...","line":N,"side":"RIGHT",
-                               "body":"<severity + title + explanation + fix>"}, ...]}
-                 One entry per finding. Only comment on lines in the PR diff.
-              3. Post it:
-                 gh api repos/<owner>/<repo>/pulls/<pr>/reviews --method POST --input /tmp/review.json
-              3. Keep your final chat message to ONE line ("Inline review posted."),
-                 because the harness posts it as a separate top-level PR comment.
-            - If the API call fails (e.g. 403 on fork PRs where the token is
-              read-only), fall back to putting the full CodeRabbit-formatted review
-              in your final message instead.
+            - **Focus areas for this repo**: Rust panics/unwraps, Tauri command misuse, TS type safety, error propagation.
+            - **Verdict:** APPROVE | REQUEST CHANGES | COMMENT
+
+            </details>
+
+            Posting CodeRabbit-style Inline Comments:
+            In addition to your final markdown review above, submit actionable findings directly onto the PR diff using the gh CLI:
+            1. Context:
+               - Repo: $GITHUB_REPOSITORY
+               - PR Number: get from $GITHUB_EVENT_PATH via `jq -r .pull_request.number "$GITHUB_EVENT_PATH"`
+               - Head SHA: `gh pr view <number> --json headRefOid --jq .headRefOid`
+            2. Check the diff hunks: run `gh pr diff <number>` to verify that any line you comment on is strictly part of the PR diff (lines added or modified). GitHub API will reject comments on lines outside the diff with HTTP 422.
+            3. If you have actionable findings on lines within the diff, post them in a single review via stdin (do NOT write files to /tmp or outside the repo workspace):
+               cat << 'EOF' | gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --method POST --input -
+               {
+                 "commit_id": "<HEAD_SHA>",
+                 "event": "COMMENT",
+                 "body": "Automated review inline suggestions.",
+                 "comments": [
+                   {
+                     "path": "path/to/file",
+                     "line": <line_number_in_diff>,
+                     "side": "RIGHT",
+                     "body": "_<Severity_Badge>_\n\n**<Short Title>**\n\n<Explanation>\n\n```suggestion\n<replacement_code>\n```"
+                   }
+                 ]
+               }
+               EOF
+            4. If the gh api command succeeds or fails (e.g. 422 due to line number or 403 on forks), do not abort. Always output the full CodeRabbit-formatted markdown review as your final message so it renders completely in the main PR comment.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -39,9 +39,33 @@ jobs:
           model: opencode/muse-spark-1.3-contributor-free
           use_github_token: true
           prompt: |
-            Review this pull request:
-            - Check for code quality issues
-            - Look for potential bugs (esp. Rust panics/unwraps, TS type errors, Tauri command misuse)
-            - Check error handling and edge cases
-            - Suggest concrete improvements with file/line references
-            - Keep the review concise; skip praise, focus on actionable findings
+            Review this pull request. Format your review EXACTLY like CodeRabbit:
+
+            ## Review — PR #<number>
+            <one-paragraph walkthrough of what the PR does>
+
+            ### Walkthrough
+            A per-file summary table:
+            | File(s) | Summary |
+            |---|---|
+            | ... | ... |
+
+            If the change involves runtime interactions, data flow, or multi-step processes,
+            include a ```mermaid sequence diagram. Omit it for trivial diffs.
+
+            ### Findings
+            Numbered, most severe first. Each finding uses this shape:
+            #### <Severity>: <short title> — `path/to/file:start-end`
+            <why it matters>
+            Fix:
+            ```<lang>
+            <concrete code>
+            ```
+            Severities: High (bug / security / data loss), Medium (correctness /
+            robustness / perf), Low (nit). Only actionable findings with file/line
+            references. No praise, no generic advice. Skip categories with no findings.
+
+            Focus areas for this repo: Rust panics/unwraps, TS type errors, Tauri command
+            misuse, error handling and edge cases.
+
+            End with one line: **Verdict:** APPROVE | REQUEST CHANGES | COMMENT

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # issue_comment defaults to the default branch; resolve the PR head
+          # so /oc commands on a PR run against PR code (falls back to github.sha
+          # for plain issues, where the agent creates a branch from HEAD).
+          ref: ${{ github.event_name == 'pull_request_review_comment' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number) || github.sha }}
           fetch-depth: 0
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -14,9 +14,11 @@ permissions: {}
 
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
   pull_request_review_comment:
-    types: [created]
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   opencode:
@@ -39,25 +41,25 @@ jobs:
     timeout-minutes: 15
     concurrency:
       group: opencode-task-${{ github.event.issue.number || github.event.pull_request.number }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # issue_comment defaults to the default branch; resolve the PR head
           # so /oc commands on a PR run against PR code (falls back to github.sha
           # for plain issues, where the agent creates a branch from HEAD).
           ref: ${{ github.event_name == 'pull_request_review_comment' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number) || github.sha }}
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
           submodules: recursive
 
       - name: Run OpenCode
-        uses: anomalyco/opencode/github@latest
+        uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a # latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,40 @@
+name: opencode
+
+# On-demand OpenCode tasks. Comment `/oc <instruction>` or
+# `/opencode <instruction>` on any issue, PR, or PR review thread, e.g.:
+#   /oc review
+#   /oc fix the failing check
+# This is also the "approve a review" path: commenting `/oc review`
+# runs a review on that PR on demand.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode/muse-spark-1.3-contributor-free
+          use_github_token: true

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -6,6 +6,11 @@ name: opencode
 #   /oc fix the failing check
 # This is also the "approve a review" path: commenting `/oc review`
 # runs a review on that PR on demand.
+#
+# Trigger is restricted to OWNER/MEMBER/COLLABORATOR comments starting
+# with the command, and ignores the bot's own replies (loop guard).
+
+permissions: {}
 
 on:
   issue_comment:
@@ -16,9 +21,25 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, '/opencode')
+      github.actor != 'github-actions[bot]' &&
+      (
+        startsWith(github.event.comment.body, '/oc ') ||
+        github.event.comment.body == '/oc' ||
+        startsWith(github.event.comment.body, '/oc\n') ||
+        startsWith(github.event.comment.body, '/opencode ') ||
+        github.event.comment.body == '/opencode' ||
+        startsWith(github.event.comment.body, '/opencode\n')
+      ) &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: opencode-task-${{ github.event.issue.number }}-${{ github.event.comment.id }}
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write
@@ -27,8 +48,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
+          submodules: recursive
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -53,7 +53,7 @@ jobs:
           # issue_comment defaults to the default branch; resolve the PR head
           # so /oc commands on a PR run against PR code (falls back to github.sha
           # for plain issues, where the agent creates a branch from HEAD).
-          ref: ${{ github.event_name == 'pull_request_review_comment' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number) || github.sha }}
+          ref: ${{ github.event_name == 'pull_request_review' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event_name == 'pull_request_review_comment' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number) || github.sha }}
           fetch-depth: 0
           persist-credentials: true
           submodules: recursive

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -25,10 +25,10 @@ jobs:
       (
         startsWith(github.event.comment.body, '/oc ') ||
         github.event.comment.body == '/oc' ||
-        startsWith(github.event.comment.body, '/oc\n') ||
+        startsWith(github.event.comment.body, fromJSON('"/oc\n"')) ||
         startsWith(github.event.comment.body, '/opencode ') ||
         github.event.comment.body == '/opencode' ||
-        startsWith(github.event.comment.body, '/opencode\n')
+        startsWith(github.event.comment.body, fromJSON('"/opencode\n"'))
       ) &&
       (
         github.event.comment.author_association == 'OWNER' ||

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:
-      group: opencode-task-${{ github.event.issue.number }}-${{ github.event.comment.id }}
+      group: opencode-task-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
       contents: write

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thumb-rs"]
+	path = thumb-rs
+	url = https://github.com/iamzubin/thumb-rs.git


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/opencode-review.yml` to run automatic OpenCode reviews on PR opened, synchronize, reopened, and ready_for_review events
- Adds `.github/workflows/opencode.yml` to handle on-demand `/oc` and `/opencode` commands on issues, PRs, and PR review threads
- Both workflows use `anomalyco/opencode/github@latest` with the `muse-spark-1.3-contributor-free` model and inject `OPENCODE_API_KEY` + `GITHUB_TOKEN`
- Review workflow checks out with `persist-credentials: false` and grants read contents, write PR, and write issues permissions

## Testing

- Not run: CI-only changes; workflows execute on GitHub, not locally
- Verified YAML syntax parses cleanly (checked manually against GitHub Actions schema)
- Confirmed event triggers (`pull_request` types, `issue_comment`, `pull_request_review_comment`) and `if` condition syntax for `/oc` / `/opencode` detection
- Not run: end-to-end PR review trigger and `/oc review` comment flow require a live GitHub repo with the `OPENCODE_API_KEY` secret configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Automation**
  - Automated code reviews now run only for non-draft pull requests.
  - Review runs are limited to authorized pull request participants and comments beginning with `/oc` or `/opencode`.
  - Duplicate review runs are managed more reliably, with time limits and improved cancellation behavior.
  - Automated checks now include the complete repository history and submodules when reviewing changes.
- **Security**
  - Workflow permissions and credential handling have been tightened to reduce unnecessary access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->