### PR TITLE
Universal native drops, in-house thumbnails, opencode review bot

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -47,6 +47,10 @@ jobs:
           model: opencode/muse-spark-1.3-contributor-free
           variant: xhigh
           use_github_token: true
+          # The action builds `opencode.ai/s/<id>` session links that 404
+          # (upstream anomalyco/opencode#26417: canonical format moved to
+          # opncd.ai/share/<id>). Disable until upstream fixes the footer.
+          share: false
           prompt: |
             Review this pull request. Format your final response EXACTLY like CodeRabbit with collapsible sections:
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -35,10 +35,12 @@ jobs:
 
       - uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a # latest
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          # No OPENCODE_API_KEY: with no Zen key configured opencode exposes
+          # only free models, and muse-spark-1.3-contributor-free is free.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode/muse-spark-1.3-contributor-free
+          variant: xhigh
           use_github_token: true
           prompt: |
             Review this pull request. Format your final response EXACTLY like CodeRabbit with collapsible sections:

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,66 @@
+name: opencode-review
+
+# Automatic PR reviews from the opencode bot (Muse Spark 1.3, free tier).
+#
+# Identity: reviews post as `opencode[bot]` (custom avatar) when the
+# OPENCODE_APP_ID / OPENCODE_APP_PRIVATE_KEY secrets are configured (see
+# setup notes below). Otherwise they fall back to `github-actions[bot]`.
+# `github-actions[bot]` itself cannot be renamed — a GitHub App is the only
+# way to get a custom bot name + display picture.
+#
+# Required secrets (repo Settings → Secrets and variables → Actions):
+#   OPENCODE_API_KEY            Zen API key from https://opencode.ai/auth
+#                               (the muse-spark-1.3-contributor-free model is $0)
+# Optional secrets (custom `opencode[bot]` identity):
+#   OPENCODE_APP_ID             GitHub App ID of your `opencode` app
+#   OPENCODE_APP_PRIVATE_KEY    Its private key (PEM contents)
+#
+# Creating the `opencode` GitHub App (one-time, ~3 min):
+#   1. https://github.com/settings/apps → New GitHub App
+#      - Name: `opencode`, Homepage URL: https://opencode.ai
+#      - Uncheck "Active" under Webhook (not needed for token minting)
+#      - Permissions: Contents: Read-only, Pull requests: Read and write,
+#        Issues: Read and write
+#      - "Where can this App be installed?": Only on this account
+#   2. Upload the opencode logo as the app's image (its avatar = bot DP).
+#   3. Install the app on iamzubin/holdem.
+#   4. Copy the App ID + generate a private key into the secrets above.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - id: app-token
+        uses: actions/create-github-app-token@v2
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.OPENCODE_APP_ID }}
+          private-key: ${{ secrets.OPENCODE_APP_PRIVATE_KEY }}
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode/muse-spark-1.3-contributor-free
+          variant: xhigh
+          use_github_token: true
+          prompt: |
+            Review this pull request:
+            - Check for code quality issues and potential bugs
+            - Flag unsafe Rust (unwarranted `unsafe`, missing cleanup) in app/src-tauri
+            - Flag React/TS issues (stale closures, missing deps, a11y) in app/src
+            - Suggest concrete improvements with file:line references
+            Keep it concise. Do not approve; just leave review findings.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -23,7 +23,9 @@ jobs:
       group: opencode-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     permissions:
-      contents: read
+      # contents:write is required for resolveReviewThread (toggles PR
+      # conversation metadata, but GitHub still gates it behind contents:write).
+      contents: write
       pull-requests: write
       issues: write
     steps:
@@ -38,6 +40,9 @@ jobs:
           # No OPENCODE_API_KEY: with no Zen key configured opencode exposes
           # only free models, and muse-spark-1.3-contributor-free is free.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gh CLI prefers GH_TOKEN; keep both in sync so `gh api graphql`
+          # calls for thread history / resolve are authenticated.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode/muse-spark-1.3-contributor-free
           variant: xhigh
@@ -107,3 +112,29 @@ jobs:
                }
                EOF
             4. If the gh api command succeeds or fails (e.g. 422 due to line number or 403 on forks), do not abort. Always output the full CodeRabbit-formatted markdown review as your final message so it renders completely in the main PR comment.
+
+            Thread History Context (avoid duplicates, track fixes):
+            Before posting new inline comments, fetch existing PR conversation so you do not re-post what is already open:
+            1. Derive context once:
+               - `PR_NUMBER=$(jq -r .pull_request.number "$GITHUB_EVENT_PATH")`
+               - `OWNER=$(jq -r .repository.owner.login "$GITHUB_EVENT_PATH")` (fallback: `echo "$GITHUB_REPOSITORY" | cut -d/ -f1`)
+               - `REPO=$(jq -r .repository.name "$GITHUB_EVENT_PATH")` (fallback: `echo "$GITHUB_REPOSITORY" | cut -d/ -f2`)
+               - Ensure auth: `export GH_TOKEN="$GITHUB_TOKEN"` if `gh` reports auth errors.
+            2. Fetch history (read-only, best-effort — continue with the diff if any call fails):
+               - General comments (unresolvable, for context only): `gh pr view "$PR_NUMBER" --json title,body,comments --jq .`
+               - Inline comments: `gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments" --paginate --jq '.[] | {id, path, line, user: .user.login, body: .body[0:500]}'`
+               - Review threads with resolution state:
+                 `gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{id,isResolved,isOutdated,path,line,comments(first:20){nodes{body,author{login},createdAt}}}}}}}' -f o="$OWNER" -f r="$REPO" -F n="$PR_NUMBER"`
+            3. Use the history to:
+               - Skip posting a new inline finding when an open (`isResolved:false`), non-outdated bot thread already covers the same `path:line` and issue.
+               - In your Verdict section, note carried-over open threads vs. newly introduced findings.
+
+            Resolve Fixed Bot Threads (bot threads only, auto on sync):
+            After completing the review above, close the loop on your own prior feedback:
+            1. From the thread list, consider only threads where `isResolved==false`, `isOutdated==false`, and the thread author / comments are from `github-actions[bot]` or `opencode-agent[bot]`.
+            2. For each such thread, verify the fix is present in the current code (`gh pr diff <number>`, `read`/`grep` the file). Only proceed when the underlying issue is actually fixed. Never resolve human threads, threads asking a question, deferred items, or anything you cannot verify.
+            3. For each verified fix, reply first then resolve (use the thread node `id` starting with `PRRT_`):
+               `gh api graphql -f query='mutation($id:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id,body:$body}){comment{id}}}' -f id="PRRT_..." -f body="Fixed in $(git rev-parse --short HEAD): <what changed>"`
+               `gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id="PRRT_..."`
+            4. General PR comments (`gh pr view` comments) are unresolvable — reply via a normal PR comment instead if needed, never attempt GraphQL resolve on them.
+            5. If any fetch/reply/resolve call fails, log it and continue. Never abort the main CodeRabbit review because of thread maintenance.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -47,10 +47,6 @@ jobs:
           model: opencode/muse-spark-1.3-contributor-free
           variant: xhigh
           use_github_token: true
-          # The action builds `opencode.ai/s/<id>` session links that 404
-          # (upstream anomalyco/opencode#26417: canonical format moved to
-          # opncd.ai/share/<id>). Disable until upstream fixes the footer.
-          share: false
           prompt: |
             Review this pull request. Format your final response EXACTLY like CodeRabbit with collapsible sections:
 
@@ -142,3 +138,20 @@ jobs:
                `gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id="PRRT_..."`
             4. General PR comments (`gh pr view` comments) are unresolvable — reply via a normal PR comment instead if needed, never attempt GraphQL resolve on them.
             5. If any fetch/reply/resolve call fails, log it and continue. Never abort the main CodeRabbit review because of thread maintenance.
+
+      # The action posts session links as `opencode.ai/s/<id>` which 404s
+      # (upstream anomalyco/opencode#26417). The same id resolves under the
+      # current `opncd.ai/share/<id>` format, so rewrite bot comments.
+      - name: Fix opencode session link
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NUM="${{ github.event.pull_request.number }}"
+          gh api "repos/$GITHUB_REPOSITORY/issues/$NUM/comments?per_page=100" \
+            --jq '[.[] | select((.user.login == "github-actions[bot]" or .user.login == "opencode-agent[bot]") and (.body | contains("https://opencode.ai/s/"))) | .id] | .[]' |
+          while read -r CID; do
+            BODY=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$CID" --jq .body)
+            FIXED=$(printf '%s' "$BODY" | sed 's#https://opencode\.ai/s/#https://opncd.ai/share/#g')
+            gh api "repos/$GITHUB_REPOSITORY/issues/comments/$CID" -X PATCH -f body="$FIXED" --silent
+          done

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -67,3 +67,7 @@ jobs:
         with:
           model: opencode/muse-spark-1.3-contributor-free
           use_github_token: true
+          # The action builds `opencode.ai/s/<id>` session links that 404
+          # (upstream anomalyco/opencode#26417: canonical format moved to
+          # opncd.ai/share/<id>). Disable until upstream fixes the footer.
+          share: false

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -4,6 +4,7 @@ name: opencode
 # `/opencode <instruction>` on any issue, PR, or PR review thread, e.g.:
 #   /oc review
 #   /oc fix the failing check
+#   /oc /resolve-threads  (reply + resolve fixed bot review threads)
 # This is also the "approve a review" path: commenting `/oc review`
 # runs a review on that PR on demand.
 #

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -67,7 +67,20 @@ jobs:
         with:
           model: opencode/muse-spark-1.3-contributor-free
           use_github_token: true
-          # The action builds `opencode.ai/s/<id>` session links that 404
-          # (upstream anomalyco/opencode#26417: canonical format moved to
-          # opncd.ai/share/<id>). Disable until upstream fixes the footer.
-          share: false
+
+      # The action posts session links as `opencode.ai/s/<id>` which 404s
+      # (upstream anomalyco/opencode#26417). The same id resolves under the
+      # current `opncd.ai/share/<id>` format, so rewrite bot comments.
+      - name: Fix opencode session link
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NUM="${{ github.event.issue.number || github.event.pull_request.number }}"
+          gh api "repos/$GITHUB_REPOSITORY/issues/$NUM/comments?per_page=100" \
+            --jq '[.[] | select((.user.login == "github-actions[bot]" or .user.login == "opencode-agent[bot]") and (.body | contains("https://opencode.ai/s/"))) | .id] | .[]' |
+          while read -r CID; do
+            BODY=$(gh api "repos/$GITHUB_REPOSITORY/issues/comments/$CID" --jq .body)
+            FIXED=$(printf '%s' "$BODY" | sed 's#https://opencode\.ai/s/#https://opncd.ai/share/#g')
+            gh api "repos/$GITHUB_REPOSITORY/issues/comments/$CID" -X PATCH -f body="$FIXED" --silent
+          done

--- a/.opencode/commands/resolve-threads.md
+++ b/.opencode/commands/resolve-threads.md
@@ -1,0 +1,25 @@
+---
+description: Resolve fixed bot review threads on the current PR (reply + resolveReviewThread)
+agent: build
+---
+
+`/oc` runs already receive PR/issue thread history as prompt context. Use this when asked to fix review feedback and/or resolve threads.
+
+1. Auth: `export GH_TOKEN="$GITHUB_TOKEN"` if `gh` reports auth errors. Derive `OWNER`/`REPO` from `$GITHUB_REPOSITORY` and `PR_NUMBER` from `$GITHUB_EVENT_PATH` (`jq -r .pull_request.number`) when running in CI; locally pass them explicitly.
+
+2. List unresolved threads (thread node `id` starts with `PRRT_`):
+
+```bash
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{id,isResolved,isOutdated,path,line,comments(first:20){nodes{body,author{login},createdAt}}}}}}}' -f o="$OWNER" -f r="$REPO" -F n="$PR_NUMBER"
+```
+
+3. Only resolve bot threads (`github-actions[bot]` / `opencode-agent[bot]`) where `isResolved==false`, `isOutdated==false`, and the fix is verified in the working tree (`read`/`grep` the file, check `gh pr diff`). Never resolve human threads, questions, or deferred items.
+
+4. Reply first, then resolve:
+
+```bash
+gh api graphql -f query='mutation($id:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id,body:$body}){comment{id}}}' -f id="PRRT_..." -f body="Fixed in <sha>: <what changed>"
+gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id="PRRT_..."
+```
+
+5. General PR comments are unresolvable — reply via a normal PR comment instead, never attempt GraphQL resolve on them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository contains three main projects:
 1. **app/** - Tauri desktop app (React + TypeScript + Vite + Tailwind)
 2. **holdem_website/** - Next.js marketing website (Next.js 15 + React 19 + Tailwind CSS)
-3. **thumb-rs** - External Rust library for thumbnail extraction (consumed via git dependency)
+3. **thumb-rs** - Git submodule with the original thumbnail-extraction source (reference only; `app/` uses its own in-house port in `src-tauri/src/thumbnail.rs`)
 
 ---
 
@@ -104,7 +104,7 @@ function cn(...inputs: (string | undefined | null | false)[]) {
 }
 ```
 
-### Rust (thumb-rs & src-tauri)
+### Rust (src-tauri)
 
 - Use explicit types in function signatures
 - Use `thiserror` for error handling with `Result<T, Error>`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,5 +42,6 @@ holdem_website/{app,components,hooks}
 
 ## Notes
 
+- Do not push unless explicitly asked to.
 - Desktop app is Windows-only (Tauri 2.x).
 - Tailwind versions differ: 3.x in `app/`, 4.x (CSS-based config) in `holdem_website/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,225 +1,46 @@
 # AGENTS.md
 
-This repository contains three main projects:
-1. **app/** - Tauri desktop app (React + TypeScript + Vite + Tailwind)
-2. **holdem_website/** - Next.js marketing website (Next.js 15 + React 19 + Tailwind CSS)
-3. **thumb-rs** - Git submodule with the original thumbnail-extraction source (reference only; `app/` uses its own in-house port in `src-tauri/src/thumbnail.rs`)
+Three projects in this repo:
+1. **app/** - Tauri desktop app (React + TypeScript + Vite + Tailwind 3.x, Windows-only)
+2. **holdem_website/** - Next.js marketing site (Next.js 15 + React 19 + Tailwind 4.x)
+3. **thumb-rs** - Git submodule, reference only; `app/` uses its own port in `src-tauri/src/thumbnail.rs`
 
----
-
-## Development Commands
-
-### app/ (Tauri Desktop App)
+## Commands
 
 ```bash
-cd app
+cd app && npm install
+npm run build         # TS check + Vite build
+npm run tauri build   # production build
+# Do not run npm run dev — the user handles that.
 
-# Install dependencies
-npm install
+cd holdem_website && npm install
+npm run dev           # dev server (:3000)
+npm run build / npm run start / npm run lint
+npx prettier --write .  # formatting (single quotes, no semicolons, width 80)
 
-# user will do npm run dev, you don't do it.
-
-# Build
-npm run build         # TypeScript check + Vite build
-npm run tauri build  # Production build
-
-# Tauri specific
-npm run tauri        # Run tauri commands
-```
-
-### holdem_website/ (Next.js Website)
-
-```bash
-cd holdem_website
-
-# Install dependencies
-npm install
-
-# Development
-npm run dev           # Start Next.js dev server (port 3000)
-
-# Build & Test
-npm run build         # Production build
-npm run start         # Start production server
-npm run lint          # Run ESLint
-
-# Format
-npx prettier --write .
-```
-
-
-### app/src-tauri/ (Rust Backend)
-
-```bash
 cd app/src-tauri
-
 cargo build
-cargo test
-cargo clippy -- -D warnings
+cargo test <name>              # single test
+cargo clippy -- -D warnings    # run before committing
 ```
 
----
+## Conventions
 
-## Code Style Guidelines
+- Files: kebab-case. Components: PascalCase. Functions/variables: camelCase.
+- Imports: `@/*` alias for `./src/*`; merge classes with `cn()` (`clsx` + `tailwind-merge`).
+- Prefer `interface` for shapes, `type` for unions. Radix UI primitives for accessible components.
+- Rust: explicit signatures, `thiserror` + `Result<T, Error>`, `AsRef<Path>` for path args.
+- Tauri: add `#[tauri::command]` in `src-tauri/src/lib.rs`, call via `invoke()` from the frontend.
 
-### General Conventions
-
-- **File Naming**: kebab-case for files (e.g., `file-utils.ts`, `use-file-management.ts`)
-- **Component Naming**: PascalCase for React components (e.g., `App.tsx`, `FileIcon.tsx`)
-- **Function Naming**: camelCase for functions and variables
-- **Import Order**:
-  1. External libraries (React, Tauri, Radix UI)
-  2. Internal components
-  3. Hooks
-  4. Lib/utilities
-  5. Types
-
-### TypeScript
-
-- Use explicit types for function parameters and return types when not obvious
-- Prefer `interface` for object shapes, `type` for unions/intersections
-- Use `strict: true` where possible (currently disabled in `app/tsconfig.json`)
-- Use path aliases: `@/*` maps to `./src/*`
-
-### React
-
-- Use functional components with hooks
-- Prefer `useCallback` and `useMemo` for performance optimization
-- Use `clsx` and `tailwind-merge` for conditional className handling
-- Use Radix UI primitives (/@radix-ui/*) for accessible components
-
-### Tailwind CSS
-
-- Use utility classes for styling
-- Use `@apply` sparingly in CSS files
-- Follow mobile-first responsive design
-- Use `tailwind-merge` with `clsx` for conditional classes:
-
-```typescript
-import { clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-function cn(...inputs: (string | undefined | null | false)[]) {
-  return twMerge(clsx(inputs));
-}
-```
-
-### Rust (src-tauri)
-
-- Use explicit types in function signatures
-- Use `thiserror` for error handling with `Result<T, Error>`
-- Use `Send + Sync` bounds where necessary
-- Prefer `std::path::Path` or `AsRef<Path>` for input arguments
-- Run `cargo clippy -- -D warnings` before committing
-
-### Imports (app/)
-
-Use path aliases with `@/` prefix:
-
-```typescript
-// Components
-import { Button } from "@/components/ui/button";
-import { DynamicFileIcon } from "@/components/FileIcon";
-
-// Hooks
-import { useFileManagement } from "@/hooks/useFileManagement";
-
-// Lib
-import { handleMultiFileDragStart } from "@/lib/fileUtils";
-import { closeWindow } from "@/lib/windowUtils";
-
-// Types
-import { FilePreview, FileWithPath } from "@/types";
-```
-
-### Formatting (holdem_website/)
-
-Prettier configuration (`.prettierrc.json`):
-- Trailing commas: all
-- Semicolons: no
-- Tab width: 2
-- Single quotes: yes
-- Print width: 80
-- Arrow parens: always
-
-Run formatting:
-```bash
-npx prettier --write .
-```
-
-### Error Handling
-
-- Use try-catch for async operations with proper error logging
-- Console errors should include context: `console.error('Failed to check config existence:', error)`
-- Use Tauri invoke with `.catch()` for command errors
-- In Rust, use `thiserror` derive for error types
-
-### Key Dependencies
-
-**app/**:
-- Tauri 2.x with plugins (fs, dialog, shell, updater, etc.)
-- React 18 + React Router DOM
-- Radix UI primitives
-- Tailwind CSS 3.x
-- dnd-kit for drag-and-drop
-
-**holdem_website/**:
-- Next.js 15 (App Router)
-- React 19
-- Motion (framer-motion)
-- Tailwind CSS 4.x
-
----
-
-## Project Structure
+## Structure
 
 ```
-/                           # Root
-├── app/                    # Tauri desktop app (Windows)
-│   ├── src/               # React frontend
-│   │   ├── components/   # UI components
-│   │   ├── hooks/        # Custom React hooks
-│   │   ├── lib/          # Utilities
-│   │   ├── pages/        # Page components
-│   │   └── types.ts      # TypeScript types
-│   └── src-tauri/        # Rust backend
-│       └── src/
-│           └── lib.rs    # Tauri commands
-└── holdem_website/        # Next.js marketing site
-    ├── app/              # App router pages
-    ├── components/       # React components
-    └── hooks/            # Custom hooks
+app/src/{components,hooks,lib,pages,types.ts}
+app/src-tauri/src/            # Rust backend (lib.rs, thumbnail.rs)
+holdem_website/{app,components,hooks}
 ```
-
----
-
-## Common Tasks
-
-### Running a Single Test (Rust)
-
-```bash
-# In app/src-tauri
-cargo test <test_name>
-```
-
-### Adding a New Tauri Command
-
-1. Add command to `app/src-tauri/src/lib.rs` with `#[tauri::command]`
-2. Import and call from frontend using `invoke('command_name')`
-3. Add TypeScript type if needed in frontend
-
-### Adding a New UI Component
-
-1. Create component in `app/src/components/`
-2. Use Radix UI primitives when available
-3. Use `cn()` utility for className merging
-4. Follow existing component patterns (e.g., Button, Dialog)
-
----
 
 ## Notes
 
-- Holdem desktop app is Windows-only
-- The `app/` project uses Tauri 2.x with staticlib, cdylib, and rlib crate types
-- Both TypeScript projects use Tailwind but different versions (3.x vs 4.x)
-- The holdem_website uses the new Tailwind 4 configuration (CSS-based)
+- Desktop app is Windows-only (Tauri 2.x).
+- Tailwind versions differ: 3.x in `app/`, 4.x (CSS-based config) in `holdem_website/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,24 @@ cargo test <test_name>
 3. Use `cn()` utility for className merging
 4. Follow existing component patterns (e.g., Button, Dialog)
 
+### GitHub Review Threads (`/oc` runs)
+
+`/oc` invocations already receive PR/issue thread history as prompt context.
+When asked to fix review feedback and/or resolve threads:
+
+1. Auth: `export GH_TOKEN="$GITHUB_TOKEN"` if `gh` reports auth errors.
+2. List unresolved threads (thread node `id` starts with `PRRT_`):
+```bash
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{id,isResolved,isOutdated,path,line,comments(first:20){nodes{body,author{login},createdAt}}}}}}}' -f o="$OWNER" -f r="$REPO" -F n="$PR_NUMBER"
+```
+3. Only resolve bot threads (`github-actions[bot]` / `opencode-agent[bot]`) where `isResolved==false`, `isOutdated==false`, and the fix is verified in the working tree. Never resolve human threads, questions, or deferred items.
+4. Reply first, then resolve:
+```bash
+gh api graphql -f query='mutation($id:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id,body:$body}){comment{id}}}' -f id="PRRT_..." -f body="Fixed in <sha>: <what changed>"
+gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id="PRRT_..."
+```
+5. General PR comments are unresolvable — reply via normal comment instead.
+
 ---
 
 ## Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,24 +215,6 @@ cargo test <test_name>
 3. Use `cn()` utility for className merging
 4. Follow existing component patterns (e.g., Button, Dialog)
 
-### GitHub Review Threads (`/oc` runs)
-
-`/oc` invocations already receive PR/issue thread history as prompt context.
-When asked to fix review feedback and/or resolve threads:
-
-1. Auth: `export GH_TOKEN="$GITHUB_TOKEN"` if `gh` reports auth errors.
-2. List unresolved threads (thread node `id` starts with `PRRT_`):
-```bash
-gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100){nodes{id,isResolved,isOutdated,path,line,comments(first:20){nodes{body,author{login},createdAt}}}}}}}' -f o="$OWNER" -f r="$REPO" -F n="$PR_NUMBER"
-```
-3. Only resolve bot threads (`github-actions[bot]` / `opencode-agent[bot]`) where `isResolved==false`, `isOutdated==false`, and the fix is verified in the working tree. Never resolve human threads, questions, or deferred items.
-4. Reply first, then resolve:
-```bash
-gh api graphql -f query='mutation($id:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id,body:$body}){comment{id}}}' -f id="PRRT_..." -f body="Fixed in <sha>: <what changed>"
-gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id="PRRT_..."
-```
-5. General PR comments are unresolvable — reply via normal comment instead.
-
 ---
 
 ## Notes

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -1865,7 +1865,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
- "thumb-rs",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -3064,9 +3064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
  "dispatch2",
- "libc",
  "objc2",
 ]
 
@@ -3077,13 +3075,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
  "dispatch2",
- "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
- "objc2-metal",
 ]
 
 [[package]]
@@ -3158,17 +3153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-metal"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
-dependencies = [
- "bitflags 2.13.1",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
 name = "objc2-osa-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,22 +3174,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-quick-look-thumbnailing"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8e00da1ca87ffe3ea8d20981026f013df91072a140432f0f88da9a356d9b3c"
-dependencies = [
- "bitflags 2.13.1",
- "block2",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "objc2-ui-kit",
 ]
 
 [[package]]
@@ -5401,22 +5369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "thumb-rs"
-version = "0.1.1"
-source = "git+https://github.com/iamzubin/thumb-rs#2a929c28d3a630627159858deb5433ad9ffb8d11"
-dependencies = [
- "block2",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "objc2-quick-look-thumbnailing",
- "thiserror 2.0.20",
- "windows 0.61.3",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -3808,6 +3808,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2 0.4.19",
  "http 1.5.0",
  "http-body 1.1.0",
@@ -3829,12 +3830,14 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
 ]
 
@@ -3873,7 +3876,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -5841,6 +5844,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ reqwest = { version = "0.12", features = ["json"] }
 posthog-rs = "0.3.5"
 tokio = "1.47.0"
 uuid = { version = "1.0", features = ["v4"] }
-thumb-rs = { git = "https://github.com/iamzubin/thumb-rs" }
+thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
@@ -40,6 +40,7 @@ windows-core = "0.61.2"
 
 windows = { version = "0.61.3", features = [
     "Win32_Foundation",
+    "Win32_Graphics_Gdi",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Shell",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ base64 = "0.22.1"
 tauri-plugin-process = "2.2.1"
 drag = { path = "drag-patch" }
 image = "0.25"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 posthog-rs = "0.3.5"
 tokio = "1.47.0"
 uuid = { version = "1.0", features = ["v4"] }

--- a/app/src-tauri/src/commands/file_ops.rs
+++ b/app/src-tauri/src/commands/file_ops.rs
@@ -1,5 +1,5 @@
 use crate::analytics;
-use crate::file::{get_dir_size, FileMetadata};
+use crate::file::FileMetadata;
 use crate::thumbnail::get_thumbnail_base64;
 use crate::{DragState, FileList};
 use std::path::PathBuf;
@@ -29,12 +29,8 @@ pub fn add_files(
         if path.exists() {
             let metadata = path.metadata().map_err(|e| e.to_string())?;
 
-            // Calculate size correctly for directories
-            let size = if metadata.is_dir() {
-                get_dir_size(&path).unwrap_or(0)
-            } else {
-                metadata.len()
-            };
+            // Directories store size 0 — no recursive walk (instant drops).
+            let size = if metadata.is_dir() { 0 } else { metadata.len() };
 
             let file = FileMetadata {
                 id: list.len() as u64,
@@ -72,6 +68,7 @@ fn sanitize_filename(name: &str) -> String {
         .chars()
         .map(|c| match c {
             '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            c if c.is_control() => '_',
             other => other,
         })
         .collect();
@@ -82,6 +79,99 @@ fn sanitize_filename(name: &str) -> String {
     }
 }
 
+fn drop_folder() -> Result<PathBuf, String> {
+    let folder_name = chrono::Local::now().format("%Y%m%d").to_string();
+    let drop_folder = std::env::temp_dir().join("holdem_drops").join(&folder_name);
+    std::fs::create_dir_all(&drop_folder)
+        .map_err(|e| format!("Failed to create drop folder: {}", e))?;
+    Ok(drop_folder)
+}
+
+/// Unique leaf name: <stem>_<HHMMSSmmm>_<rand8>.<ext> — avoids the old
+/// second-resolution collisions when one physical drop fires multiple events.
+fn unique_file_name(stem: &str, ext: &str) -> String {
+    let stem = sanitize_filename(stem);
+    let stem = stem.trim();
+    let stem = if stem.is_empty() { "unnamed" } else { stem };
+    // Truncate very long stems (Outlook subjects, URLs) to keep paths valid.
+    let stem: String = stem.chars().take(80).collect();
+    let ts = chrono::Local::now().format("%H%M%S%3f").to_string();
+    let rand: String = uuid::Uuid::new_v4().to_string()[..8].to_string();
+    if ext.is_empty() {
+        format!("{}_{}_{}", stem, ts, rand)
+    } else {
+        format!("{}_{}_{}.{}", stem, ts, rand, sanitize_filename(ext))
+    }
+}
+
+fn unique_path_in(folder: &std::path::Path, file_name: &str) -> PathBuf {
+    let mut p = folder.join(file_name);
+    // Belt-and-braces in the astronomically unlikely case of a collision.
+    let mut n = 1;
+    while p.exists() {
+        let stem = std::path::Path::new(file_name)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("drop");
+        let ext = std::path::Path::new(file_name)
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        let alt = if ext.is_empty() {
+            format!("{}_{}", stem, n)
+        } else {
+            format!("{}_{}.{}", stem, n, ext)
+        };
+        p = folder.join(alt);
+        n += 1;
+    }
+    p
+}
+
+/// Write raw bytes to today's drop folder with a unique name.
+/// Used by the native drop target for virtual files (FileGroupDescriptor),
+/// bitmaps (CF_DIB/PNG) and fetched web images.
+pub fn save_bytes_to_drop_folder(
+    bytes: &[u8],
+    suggested_name: &str,
+    default_ext: &str,
+) -> Result<String, String> {
+    use std::io::Write;
+    let folder = drop_folder()?;
+    let (stem, ext) = split_stem_ext(suggested_name, default_ext);
+    let name = unique_file_name(&stem, &ext);
+    let path = unique_path_in(&folder, &name);
+    let mut file = std::fs::File::create(&path).map_err(|e| e.to_string())?;
+    file.write_all(bytes).map_err(|e| e.to_string())?;
+    Ok(path.to_string_lossy().to_string())
+}
+
+fn split_stem_ext(suggested: &str, default_ext: &str) -> (String, String) {
+    let clean = suggested.trim();
+    if clean.is_empty() {
+        return ("drop".to_string(), default_ext.to_string());
+    }
+    let p = std::path::Path::new(clean);
+    let stem = p
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("drop")
+        .to_string();
+    let ext = p
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or(default_ext)
+        .to_string();
+    (stem, ext)
+}
+
+/// Save a URL that could not be fetched (auth-walled, blob:, non-image)
+/// as a tiny `.url` placeholder so the drop is never silently lost.
+pub fn save_url_placeholder(url: &str) -> Result<String, String> {
+    let body = format!("[InternetShortcut]\nURL={}\n", url);
+    save_bytes_to_drop_folder(body.as_bytes(), "link", "url")
+}
+
 #[tauri::command]
 pub fn save_pasted_text(
     text: String,
@@ -89,19 +179,20 @@ pub fn save_pasted_text(
     original_name: Option<String>,
 ) -> Result<String, String> {
     use std::io::Write;
-    let timestamp = chrono::Local::now();
-    let folder_name = timestamp.format("%Y%m%d").to_string();
-    let drop_folder = std::env::temp_dir().join("holdem_drops").join(&folder_name);
-    if let Err(e) = std::fs::create_dir_all(&drop_folder) {
-        return Err(format!("Failed to create drop folder: {}", e));
-    }
-
-    let file_name = if let Some(name) = original_name.as_deref().filter(|n| !n.trim().is_empty()) {
-        sanitize_filename(name)
+    let folder = drop_folder()?;
+    let ext = if extension.trim().is_empty() {
+        "txt"
     } else {
-        format!("note_{}.{}", timestamp.format("%H%M%S"), extension)
+        extension.trim()
     };
-    let new_path = drop_folder.join(&file_name);
+    let file_name = if let Some(name) = original_name.as_deref().filter(|n| !n.trim().is_empty()) {
+        // Even explicit names get uniquified to survive duplicate drop events.
+        let (stem, ext2) = split_stem_ext(name, ext);
+        unique_file_name(&stem, &ext2)
+    } else {
+        unique_file_name("note", ext)
+    };
+    let new_path = unique_path_in(&folder, &file_name);
 
     let mut file = std::fs::File::create(&new_path).map_err(|e| e.to_string())?;
     file.write_all(text.as_bytes()).map_err(|e| e.to_string())?;
@@ -116,26 +207,33 @@ pub fn save_pasted_data_base64(
     original_name: Option<String>,
 ) -> Result<String, String> {
     use base64::{engine::general_purpose, Engine as _};
-    use std::io::Write;
 
+    // Accept both raw base64 and full `data:...;base64,...` URLs (frontend
+    // blob: forwarder sends raw, browser <img> sends full).
+    let b64 = data_base64
+        .split_once(',')
+        .map(|(_, rest)| rest)
+        .unwrap_or(&data_base64);
+    let b64 = b64.trim();
     let bytes = general_purpose::STANDARD
-        .decode(data_base64)
+        .decode(b64)
         .map_err(|e| e.to_string())?;
 
-    let timestamp = chrono::Local::now();
-    let folder_name = timestamp.format("%Y%m%d").to_string();
-    let drop_folder = std::env::temp_dir().join("holdem_drops").join(&folder_name);
-    if let Err(e) = std::fs::create_dir_all(&drop_folder) {
-        return Err(format!("Failed to create drop folder: {}", e));
-    }
-
-    let file_name = if let Some(name) = original_name.as_deref().filter(|n| !n.trim().is_empty()) {
-        sanitize_filename(name)
+    let ext = if extension.trim().is_empty() {
+        "png"
     } else {
-        format!("drop_{}.{}", timestamp.format("%H%M%S"), extension)
+        extension.trim()
     };
-    let new_path = drop_folder.join(&file_name);
+    let file_name = if let Some(name) = original_name.as_deref().filter(|n| !n.trim().is_empty()) {
+        let (stem, ext2) = split_stem_ext(name, ext);
+        unique_file_name(&stem, &ext2)
+    } else {
+        unique_file_name("drop", ext)
+    };
+    let folder = drop_folder()?;
+    let new_path = unique_path_in(&folder, &file_name);
 
+    use std::io::Write;
     let mut file = std::fs::File::create(&new_path).map_err(|e| e.to_string())?;
     file.write_all(&bytes).map_err(|e| e.to_string())?;
 
@@ -143,53 +241,97 @@ pub fn save_pasted_data_base64(
 }
 
 #[tauri::command]
-pub async fn download_image_to_shelf(url: String) -> Result<String, String> {
-    use std::io::Write;
-    let timestamp = chrono::Local::now();
-    let folder_name = timestamp.format("%Y%m%d").to_string();
-    let drop_folder = std::env::temp_dir().join("holdem_drops").join(&folder_name);
-    if let Err(e) = std::fs::create_dir_all(&drop_folder) {
-        return Err(format!("Failed to create drop folder: {}", e));
+pub async fn download_image_to_shelf(
+    url: String,
+    referer: Option<String>,
+) -> Result<String, String> {
+    if url.starts_with("blob:") {
+        // Opaque to backend by design — frontend must fetch it where the
+        // drag originated. Save a placeholder so the drop isn't lost.
+        return save_url_placeholder(&url);
     }
 
-    let (file_name, ext) = if let Ok(parsed_url) = url::Url::parse(&url) {
+    let (suggested, ext_guess) = if let Ok(parsed_url) = url::Url::parse(&url) {
         let path_segment = parsed_url
             .path_segments()
             .and_then(|mut segs| segs.next_back())
             .unwrap_or("");
-        
         let path_obj = std::path::Path::new(path_segment);
         let extracted_ext = path_obj
             .extension()
             .and_then(|e| e.to_str())
             .unwrap_or("");
-
-        if !path_segment.is_empty() && !extracted_ext.is_empty() {
+        // Strip query-driven junk; keep real filenames, else generic.
+        if !path_segment.is_empty()
+            && !extracted_ext.is_empty()
+            && extracted_ext.len() <= 5
+        {
             (sanitize_filename(path_segment), extracted_ext.to_string())
         } else {
-            let ext = if !extracted_ext.is_empty() { extracted_ext } else { "png" };
-            (format!("download_{}.{}", timestamp.format("%H%M%S"), ext), ext.to_string())
+            ("download".to_string(), "png".to_string())
         }
     } else {
-        ("download_image.png".to_string(), "png".to_string())
+        ("download".to_string(), "png".to_string())
+    };
+    let _ = ext_guess;
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) Holdem/1.0")
+        .build()
+        .map_err(|e| e.to_string())?;
+    let mut req = client
+        .get(&url)
+        .header(reqwest::header::ACCEPT, "image/*,*/*;q=0.8");
+    if let Some(r) = referer.as_deref().filter(|s| !s.is_empty()) {
+        req = req.header(reqwest::header::REFERER, r.to_string());
+    }
+    let response = req.send().await.map_err(|e| e.to_string())?;
+    let status = response.status();
+    if !status.is_success() {
+        // Auth-walled / hotlink-protected (401/403) — keep URL, not HTML error page.
+        return save_url_placeholder(&url);
+    }
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    // 25 MB cap — don't buffer huge videos disguised as images.
+    const MAX_BYTES: usize = 25 * 1024 * 1024;
+    let bytes = response.bytes().await.map_err(|e| e.to_string())?;
+    if bytes.len() > MAX_BYTES {
+        return Err("Downloaded file exceeds 25 MB limit".to_string());
+    }
+    let ext = if content_type.starts_with("image/png") {
+        "png"
+    } else if content_type.starts_with("image/jpeg") {
+        "jpg"
+    } else if content_type.starts_with("image/webp") {
+        "webp"
+    } else if content_type.starts_with("image/gif") {
+        "gif"
+    } else if content_type.starts_with("image/svg") {
+        "svg"
+    } else if content_type.starts_with("image/") {
+        content_type
+            .split('/')
+            .nth(1)
+            .and_then(|s| s.split(';').next())
+            .unwrap_or("png")
+    } else if content_type.is_empty() || content_type.starts_with("application/octet-stream") {
+        // No content-type — fall back to URL extension guess.
+        std::path::Path::new(&suggested)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("png")
+    } else {
+        // HTML login wall etc. — don't save corrupt file.
+        return save_url_placeholder(&url);
     };
 
-    let mut new_path = drop_folder.join(&file_name);
-    if new_path.exists() {
-        let stem = std::path::Path::new(&file_name)
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("download");
-        new_path = drop_folder.join(format!("{}_{}.{}", stem, timestamp.format("%H%M%S"), ext));
-    }
-
-    let response = reqwest::get(&url).await.map_err(|e| e.to_string())?;
-    let bytes = response.bytes().await.map_err(|e| e.to_string())?;
-
-    let mut file = std::fs::File::create(&new_path).map_err(|e| e.to_string())?;
-    file.write_all(&bytes).map_err(|e| e.to_string())?;
-
-    Ok(new_path.to_string_lossy().to_string())
+    save_bytes_to_drop_folder(&bytes, &suggested, ext)
 }
 #[tauri::command]
 pub fn remove_files(

--- a/app/src-tauri/src/commands/file_ops.rs
+++ b/app/src-tauri/src/commands/file_ops.rs
@@ -24,6 +24,7 @@ pub fn add_files(
         .lock()
         .map_err(|_| "Failed to acquire lock".to_string())?;
 
+    let mut changed = false;
     for path_str in files.iter() {
         let path = PathBuf::from(path_str);
         if path.exists() {
@@ -53,11 +54,17 @@ pub fn add_files(
             // Avoid duplicates
             if !list.iter().any(|f| f.path == file.path) {
                 list.push(file);
+                changed = true;
             }
-            app_handle
-                .emit("files_updated", ())
-                .map_err(|e| e.to_string())?;
         }
+    }
+    drop(list);
+
+    // Single emit per batch — N emits for N files thrashed the frontend.
+    if changed {
+        app_handle
+            .emit("files_updated", ())
+            .map_err(|e| e.to_string())?;
     }
 
     Ok(())
@@ -251,7 +258,7 @@ pub async fn download_image_to_shelf(
         return save_url_placeholder(&url);
     }
 
-    let (suggested, ext_guess) = if let Ok(parsed_url) = url::Url::parse(&url) {
+    let suggested = if let Ok(parsed_url) = url::Url::parse(&url) {
         let path_segment = parsed_url
             .path_segments()
             .and_then(|mut segs| segs.next_back())
@@ -266,14 +273,13 @@ pub async fn download_image_to_shelf(
             && !extracted_ext.is_empty()
             && extracted_ext.len() <= 5
         {
-            (sanitize_filename(path_segment), extracted_ext.to_string())
+            sanitize_filename(path_segment)
         } else {
-            ("download".to_string(), "png".to_string())
+            "download".to_string()
         }
     } else {
-        ("download".to_string(), "png".to_string())
+        "download".to_string()
     };
-    let _ = ext_guess;
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(15))
@@ -286,11 +292,20 @@ pub async fn download_image_to_shelf(
     if let Some(r) = referer.as_deref().filter(|s| !s.is_empty()) {
         req = req.header(reqwest::header::REFERER, r.to_string());
     }
-    let response = req.send().await.map_err(|e| e.to_string())?;
+    let mut response = req.send().await.map_err(|e| e.to_string())?;
     let status = response.status();
     if !status.is_success() {
         // Auth-walled / hotlink-protected (401/403) — keep URL, not HTML error page.
         return save_url_placeholder(&url);
+    }
+    // 25 MB cap — don't buffer huge videos disguised as images.
+    // Check declared length up front, then stream with a running cap so a
+    // lying/missing content-length can't OOM us in `bytes()`.
+    const MAX_BYTES: usize = 25 * 1024 * 1024;
+    if let Some(len) = response.content_length() {
+        if len > MAX_BYTES as u64 {
+            return Err("Downloaded file exceeds 25 MB limit".to_string());
+        }
     }
     let content_type = response
         .headers()
@@ -298,11 +313,12 @@ pub async fn download_image_to_shelf(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_string();
-    // 25 MB cap — don't buffer huge videos disguised as images.
-    const MAX_BYTES: usize = 25 * 1024 * 1024;
-    let bytes = response.bytes().await.map_err(|e| e.to_string())?;
-    if bytes.len() > MAX_BYTES {
-        return Err("Downloaded file exceeds 25 MB limit".to_string());
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| e.to_string())? {
+        bytes.extend_from_slice(&chunk);
+        if bytes.len() > MAX_BYTES {
+            return Err("Downloaded file exceeds 25 MB limit".to_string());
+        }
     }
     let ext = if content_type.starts_with("image/png") {
         "png"
@@ -462,6 +478,5 @@ pub fn get_file_icon_base64(
     _file_list: State<'_, FileList>,
     file_path: &str,
 ) -> Result<String, String> {
-    let file_path = file_path.to_string();
-    get_thumbnail_base64(&file_path).map_err(|e| e.to_string())
+    get_thumbnail_base64(std::path::Path::new(file_path)).map_err(|e| e.to_string())
 }

--- a/app/src-tauri/src/drop_target.rs
+++ b/app/src-tauri/src/drop_target.rs
@@ -19,7 +19,7 @@ use windows::Win32::System::Ole::{
     CF_UNICODETEXT, DROPEFFECT, DROPEFFECT_COPY,
 };
 use windows::Win32::System::SystemServices::MODIFIERKEYS_FLAGS;
-use windows::Win32::UI::Shell::{DragFinish, DragQueryFileW, HDROP};
+use windows::Win32::UI::Shell::{DragQueryFileW, HDROP};
 use windows::Win32::UI::WindowsAndMessaging::EnumChildWindows;
 
 #[implement(IDropTarget)]
@@ -56,7 +56,9 @@ impl HoldemDropTarget {
                 paths.push(PathBuf::from(OsString::from_wide(&path_buf)));
             }
 
-            DragFinish(hdrop);
+            // NOTE: no DragFinish here — that is only for WM_DROPFILES HDROPs.
+            // This HGLOBAL comes from IDataObject::GetData and is owned by the
+            // STGMEDIUM; ReleaseStgMedium frees it. Calling both double-frees.
             ReleaseStgMedium(&mut medium);
 
             if !paths.is_empty() {
@@ -100,16 +102,16 @@ impl HoldemDropTarget {
                 Some(&mut read as *mut u32),
             );
             if hr.is_err() {
-                break;
+                warn!("Virtual file stream read failed, rejecting partial data");
+                return None;
             }
             if read == 0 {
                 break;
             }
             out.extend_from_slice(&buf[..read as usize]);
-            // 64 MB cap for a single virtual file — protects against runaway streams.
             if out.len() > 64 * 1024 * 1024 {
-                warn!("Virtual file stream exceeds 64 MB cap, truncating");
-                break;
+                warn!("Virtual file stream exceeds 64 MB cap, rejecting");
+                return None;
             }
         }
         if out.is_empty() {
@@ -187,9 +189,12 @@ impl HoldemDropTarget {
         if bytes.len() < 2 {
             return None;
         }
-        let count = bytes.len() / 2;
-        let wide: &[u16] =
-            std::slice::from_raw_parts(bytes.as_ptr() as *const u16, count);
+        // NOTE: no raw `*const u16` cast — `Vec<u8>` is align-1 and the
+        // allocation can be odd-aligned (UB even on x86-64). Decode LE pairs.
+        let wide: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
         let end = wide.iter().position(|&c| c == 0).unwrap_or(wide.len());
         let s = String::from_utf16_lossy(&wide[..end]);
         if s.is_empty() {
@@ -278,9 +283,10 @@ impl HoldemDropTarget {
             desc_bytes[2],
             desc_bytes[3],
         ]) as usize;
-        if count == 0 || count > 64 {
+        if count == 0 || count > 512 {
             return None;
         }
+        let count = count.min(64);
         // FILEGROUPDESCRIPTORW is packed(1): never take field references
         // (E0793 unaligned). Parse by byte offsets instead:
         //   dwFlags(4) + clsid(16) + sizel(8) + pointl(8) + dwFileAttributes(4)
@@ -560,6 +566,18 @@ pub fn register_main_drop_target(app_handle: &AppHandle, hwnd: HWND) {
 
 // --- HTML parsing -----------------------------------------------------------
 
+/// Clamp a byte index to the nearest preceding char boundary.
+/// `StartFragment`/`EndFragment` are byte offsets into the original
+/// `HTML Format` bytes; after `from_utf8_lossy` the length can shift and the
+/// offsets can split UTF-8. Slicing there panics (web-controlled input).
+fn floor_char_boundary(s: &str, mut idx: usize) -> usize {
+    idx = idx.min(s.len());
+    while idx > 0 && !s.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    idx
+}
+
 /// Returns (all image srcs in order, optional SourceURL referer).
 /// Honors StartFragment/EndFragment offsets, decodes entities, handles
 /// //host URLs and srcset. blob: URLs are kept — the caller saves a
@@ -567,7 +585,9 @@ pub fn register_main_drop_target(app_handle: &AppHandle, hwnd: HWND) {
 fn parse_html_images(html: &str) -> (Vec<String>, Option<String>) {
     let referer = parse_html_source_url(html);
     let (frag_start, frag_end) = parse_fragment_offsets(html);
-    let frag = &html[frag_start.min(html.len())..frag_end.min(html.len())];
+    let s = floor_char_boundary(html, frag_start.min(html.len()));
+    let e = floor_char_boundary(html, frag_end.min(html.len()));
+    let frag = if s <= e { &html[s..e] } else { html };
 
     let mut srcs = Vec::new();
     let mut rest = frag;
@@ -866,7 +886,7 @@ fn dib_bytes_to_png(dib: &[u8]) -> Option<Vec<u8>> {
     let bit_count = read_u16(14);
     let compression = read_u32(16);
 
-    if width <= 0 || width > 16384 || height_raw == 0 || height_raw.abs() > 16384 {
+    if width <= 0 || width > 16384 || height_raw == 0 || height_raw.unsigned_abs() > 16384 {
         return None;
     }
     if planes != 1 {
@@ -906,6 +926,10 @@ fn dib_bytes_to_png(dib: &[u8]) -> Option<Vec<u8>> {
     let mut rgba = Vec::with_capacity((width_u * height_u * 4) as usize);
     match bit_count {
         32 => {
+            // For 32bpp BI_RGB the 4th byte is undefined — most sources leave
+            // it 0, which would make the PNG fully transparent. If every
+            // alpha byte is 0, treat the image as opaque instead.
+            let mut any_alpha = false;
             for row in 0..height_u as usize {
                 let src_row = if top_down {
                     row
@@ -919,7 +943,15 @@ fn dib_bytes_to_png(dib: &[u8]) -> Option<Vec<u8>> {
                     let g = dib[o + 1];
                     let r = dib[o + 2];
                     let a = dib[o + 3];
+                    if a != 0 {
+                        any_alpha = true;
+                    }
                     rgba.extend_from_slice(&[r, g, b, a]);
+                }
+            }
+            if !any_alpha {
+                for px in rgba.chunks_mut(4) {
+                    px[3] = 255;
                 }
             }
         }
@@ -986,5 +1018,41 @@ mod tests {
             normalize_img_src("//cdn.com/x.png"),
             "https://cdn.com/x.png"
         );
+    }
+
+    #[test]
+    fn fragment_slice_never_panics_on_split_utf8() {
+        // `é` is 2 bytes in UTF-8; offsets splitting it must clamp, not panic.
+        let html = "aaé<img src=\"https://a.com/1.png\">";
+        let mid = html.find('é').unwrap() + 1; // middle of `é`
+        let s = floor_char_boundary(html, mid);
+        let e = floor_char_boundary(html, mid);
+        assert!(html.is_char_boundary(s));
+        assert!(html.is_char_boundary(e));
+        let _ = &html[s..e];
+
+        // End-to-end: bogus fragment offsets from drag source can't crash us.
+        let evil = format!(
+            "Version:0.9\r\nStartFragment:{:08}\r\nEndFragment:{:08}\r\n{}",
+            mid, mid, html
+        );
+        let (srcs, _) = parse_html_images(&evil);
+        assert!(srcs.len() <= 1);
+    }
+
+    #[test]
+    fn dib_rejects_extreme_dimensions_without_panic() {
+        // i32::MIN must not panic via abs(); unsigned_abs path rejects it.
+        let h: i32 = i32::MIN;
+        assert!(h.unsigned_abs() > 16384);
+        // Minimal DIB with hostile dims returns None instead of allocating.
+        let mut dib = vec![0u8; 40];
+        dib[0] = 40; // header_size
+        dib[4..8].copy_from_slice(&20000i32.to_le_bytes()); // width too big
+        dib[8..12].copy_from_slice(&1i32.to_le_bytes());
+        assert!(dib_bytes_to_png(&dib).is_none());
+        dib[4..8].copy_from_slice(&1i32.to_le_bytes());
+        dib[8..12].copy_from_slice(&i32::MIN.to_le_bytes());
+        assert!(dib_bytes_to_png(&dib).is_none());
     }
 }

--- a/app/src-tauri/src/drop_target.rs
+++ b/app/src-tauri/src/drop_target.rs
@@ -5,21 +5,22 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tauri::{AppHandle, Manager};
-use tracing::{error, info};
-use windows::core::{implement, w};
-use windows::Win32::Foundation::{HWND, POINTL};
+use tracing::{error, info, warn};
+use windows::core::{implement, w, BOOL};
+use windows::Win32::Foundation::{HWND, LPARAM, POINTL};
 use windows::Win32::System::Com::{
-    IDataObject, DVASPECT_CONTENT, FORMATETC, TYMED_HGLOBAL,
+    IDataObject, DVASPECT_CONTENT, FORMATETC, STGMEDIUM, TYMED_HGLOBAL, TYMED_ISTREAM,
 };
 use windows::Win32::System::Ole::ReleaseStgMedium;
 use windows::Win32::System::DataExchange::RegisterClipboardFormatW;
 use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
 use windows::Win32::System::Ole::{
-    IDropTarget, IDropTarget_Impl, RegisterDragDrop, RevokeDragDrop, CF_HDROP, DROPEFFECT,
-    DROPEFFECT_COPY,
+    IDropTarget, IDropTarget_Impl, RegisterDragDrop, RevokeDragDrop, CF_DIB, CF_DIBV5, CF_HDROP,
+    CF_UNICODETEXT, DROPEFFECT, DROPEFFECT_COPY,
 };
 use windows::Win32::System::SystemServices::MODIFIERKEYS_FLAGS;
 use windows::Win32::UI::Shell::{DragFinish, DragQueryFileW, HDROP};
+use windows::Win32::UI::WindowsAndMessaging::EnumChildWindows;
 
 #[implement(IDropTarget)]
 pub struct HoldemDropTarget {
@@ -65,66 +66,270 @@ impl HoldemDropTarget {
         None
     }
 
-    unsafe fn extract_html(&self, data_obj: &IDataObject) -> Option<String> {
-        let html_fmt_id = RegisterClipboardFormatW(w!("HTML Format"));
-        if html_fmt_id == 0 {
+    unsafe fn get_hglobal_bytes(&self, medium: &STGMEDIUM) -> Option<Vec<u8>> {
+        if medium.tymed != TYMED_HGLOBAL.0 as u32 {
             return None;
         }
+        let hglobal = medium.u.hGlobal;
+        if hglobal.is_invalid() {
+            return None;
+        }
+        let ptr = GlobalLock(hglobal) as *const u8;
+        if ptr.is_null() {
+            return None;
+        }
+        let size = GlobalSize(hglobal);
+        let bytes = std::slice::from_raw_parts(ptr, size).to_vec();
+        let _ = GlobalUnlock(hglobal);
+        Some(bytes)
+    }
 
-        let fmt = FORMATETC {
-            cfFormat: html_fmt_id as u16,
-            ptd: std::ptr::null_mut(),
-            dwAspect: DVASPECT_CONTENT.0,
-            lindex: -1,
-            tymed: TYMED_HGLOBAL.0 as u32,
-        };
+    unsafe fn read_istream_bytes(&self, medium: &STGMEDIUM) -> Option<Vec<u8>> {
+        if medium.tymed != TYMED_ISTREAM.0 as u32 {
+            return None;
+        }
+        let stream_guard = medium.u.pstm.as_ref();
+        let stream = stream_guard.as_ref()?;
+        let mut out = Vec::new();
+        let mut buf = vec![0u8; 65536];
+        loop {
+            let mut read: u32 = 0;
+            let hr = stream.Read(
+                buf.as_mut_ptr() as *mut _,
+                buf.len() as u32,
+                Some(&mut read as *mut u32),
+            );
+            if hr.is_err() {
+                break;
+            }
+            if read == 0 {
+                break;
+            }
+            out.extend_from_slice(&buf[..read as usize]);
+            // 64 MB cap for a single virtual file — protects against runaway streams.
+            if out.len() > 64 * 1024 * 1024 {
+                warn!("Virtual file stream exceeds 64 MB cap, truncating");
+                break;
+            }
+        }
+        if out.is_empty() {
+            None
+        } else {
+            Some(out)
+        }
+    }
 
-        if let Ok(mut medium) = data_obj.GetData(&fmt) {
-            let hglobal = medium.u.hGlobal;
-            let mut text = None;
-            if !hglobal.is_invalid() {
-                let ptr = GlobalLock(hglobal) as *const u8;
-                if !ptr.is_null() {
-                    let size = GlobalSize(hglobal);
-                    let slice = std::slice::from_raw_parts(ptr, size);
-                    let end = slice.iter().position(|&c| c == 0).unwrap_or(slice.len());
-                    text = Some(String::from_utf8_lossy(&slice[..end]).into_owned());
-                    let _ = GlobalUnlock(hglobal);
+    unsafe fn get_data_bytes(
+        &self,
+        data_obj: &IDataObject,
+        cf_format: u16,
+        lindex: i32,
+    ) -> Option<Vec<u8>> {
+        // Prefer IStream (virtual files, large PNGs), fall back to HGLOBAL.
+        for tymed in [TYMED_ISTREAM.0 as u32, TYMED_HGLOBAL.0 as u32] {
+            let fmt = FORMATETC {
+                cfFormat: cf_format,
+                ptd: std::ptr::null_mut(),
+                dwAspect: DVASPECT_CONTENT.0,
+                lindex,
+                tymed,
+            };
+            if let Ok(mut medium) = data_obj.GetData(&fmt) {
+                let bytes = if medium.tymed == TYMED_ISTREAM.0 as u32 {
+                    self.read_istream_bytes(&medium)
+                } else {
+                    self.get_hglobal_bytes(&medium)
+                };
+                ReleaseStgMedium(&mut medium);
+                if let Some(b) = bytes {
+                    if !b.is_empty() {
+                        return Some(b);
+                    }
                 }
             }
-            ReleaseStgMedium(&mut medium);
-            return text;
         }
         None
     }
 
-    unsafe fn extract_text(&self, data_obj: &IDataObject) -> Option<String> {
-        let fmt = FORMATETC {
-            cfFormat: 13, // CF_UNICODETEXT
-            ptd: std::ptr::null_mut(),
-            dwAspect: DVASPECT_CONTENT.0,
-            lindex: -1,
-            tymed: TYMED_HGLOBAL.0 as u32,
+    unsafe fn clipboard_format(&self, name: &str) -> Option<u16> {
+        // RegisterClipboardFormatW only takes wide literals via w!; match known names.
+        let id = match name {
+            "HTML Format" => RegisterClipboardFormatW(w!("HTML Format")),
+            "FileGroupDescriptorW" => RegisterClipboardFormatW(w!("FileGroupDescriptorW")),
+            "FileContents" => RegisterClipboardFormatW(w!("FileContents")),
+            "UniformResourceLocatorW" => {
+                RegisterClipboardFormatW(w!("UniformResourceLocatorW"))
+            }
+            "UniformResourceLocator" => RegisterClipboardFormatW(w!("UniformResourceLocator")),
+            "PNG" => RegisterClipboardFormatW(w!("PNG")),
+            _ => return None,
         };
+        if id == 0 {
+            None
+        } else {
+            Some(id as u16)
+        }
+    }
 
-        if let Ok(mut medium) = data_obj.GetData(&fmt) {
-            let hglobal = medium.u.hGlobal;
-            let mut text = None;
-            if !hglobal.is_invalid() {
-                let ptr = GlobalLock(hglobal) as *const u16;
-                if !ptr.is_null() {
-                    let size = GlobalSize(hglobal);
-                    let count = size / 2;
-                    let slice = std::slice::from_raw_parts(ptr, count);
-                    let end = slice.iter().position(|&c| c == 0).unwrap_or(slice.len());
-                    text = Some(String::from_utf16_lossy(&slice[..end]));
-                    let _ = GlobalUnlock(hglobal);
+    unsafe fn extract_html_raw(&self, data_obj: &IDataObject) -> Option<String> {
+        let cf = self.clipboard_format("HTML Format")?;
+        let bytes = self.get_data_bytes(data_obj, cf, -1)?;
+        let end = bytes.iter().position(|&c| c == 0).unwrap_or(bytes.len());
+        Some(String::from_utf8_lossy(&bytes[..end]).into_owned())
+    }
+
+    unsafe fn extract_unicode_text_with_format(
+        &self,
+        data_obj: &IDataObject,
+        cf: u16,
+    ) -> Option<String> {
+        let bytes = self.get_data_bytes(data_obj, cf, -1)?;
+        if bytes.len() < 2 {
+            return None;
+        }
+        let count = bytes.len() / 2;
+        let wide: &[u16] =
+            std::slice::from_raw_parts(bytes.as_ptr() as *const u16, count);
+        let end = wide.iter().position(|&c| c == 0).unwrap_or(wide.len());
+        let s = String::from_utf16_lossy(&wide[..end]);
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    }
+
+    unsafe fn extract_ansi_text_with_format(
+        &self,
+        data_obj: &IDataObject,
+        cf: u16,
+    ) -> Option<String> {
+        let bytes = self.get_data_bytes(data_obj, cf, -1)?;
+        let end = bytes.iter().position(|&c| c == 0).unwrap_or(bytes.len());
+        let s = String::from_utf8_lossy(&bytes[..end]).trim().to_string();
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    }
+
+    unsafe fn extract_text(&self, data_obj: &IDataObject) -> Option<String> {
+        self.extract_unicode_text_with_format(data_obj, CF_UNICODETEXT.0)
+    }
+
+    /// Explicit URL flavors (address-bar / link drags). Disambiguates real
+    /// URL drags from plain text that merely happens to start with http.
+    unsafe fn extract_url(&self, data_obj: &IDataObject) -> Option<String> {
+        if let Some(cf) = self.clipboard_format("UniformResourceLocatorW") {
+            if let Some(s) = self.extract_unicode_text_with_format(data_obj, cf) {
+                let t = s.trim().to_string();
+                if !t.is_empty() {
+                    return Some(t);
                 }
             }
-            ReleaseStgMedium(&mut medium);
-            return text;
+        }
+        if let Some(cf) = self.clipboard_format("UniformResourceLocator") {
+            if let Some(s) = self.extract_ansi_text_with_format(data_obj, cf) {
+                let t = s.trim().to_string();
+                if !t.is_empty() {
+                    return Some(t);
+                }
+            }
         }
         None
+    }
+
+    /// Raw PNG bytes when the source offers the "PNG" clipboard format
+    /// (Snipping Tool, browsers, Office image drags).
+    unsafe fn extract_png_bytes(&self, data_obj: &IDataObject) -> Option<Vec<u8>> {
+        let cf = self.clipboard_format("PNG")?;
+        self.get_data_bytes(data_obj, cf, -1)
+    }
+
+    /// CF_DIB / CF_DIBV5 (device-independent bitmap) -> PNG bytes via `image`.
+    /// Covers screenshots and canvas drags that expose only a bitmap.
+    unsafe fn extract_dib_png_bytes(&self, data_obj: &IDataObject) -> Option<Vec<u8>> {
+        for cf in [CF_DIB.0, CF_DIBV5.0] {
+            if let Some(bytes) = self.get_data_bytes(data_obj, cf, -1) {
+                if let Some(png) = dib_bytes_to_png(&bytes) {
+                    return Some(png);
+                }
+            }
+        }
+        None
+    }
+
+    /// Virtual files: Outlook attachments, Discord/Slack, ZIP folders, FTP —
+    /// exposed as FileGroupDescriptorW + FileContents (per-file lindex).
+    unsafe fn extract_virtual_files(
+        &self,
+        data_obj: &IDataObject,
+    ) -> Option<Vec<(String, Vec<u8>)>> {
+        let cf_desc = self.clipboard_format("FileGroupDescriptorW")?;
+        let cf_contents = self.clipboard_format("FileContents")?;
+        let desc_bytes = self.get_data_bytes(data_obj, cf_desc, -1)?;
+        if desc_bytes.len() < 4 {
+            return None;
+        }
+        let count = u32::from_le_bytes([
+            desc_bytes[0],
+            desc_bytes[1],
+            desc_bytes[2],
+            desc_bytes[3],
+        ]) as usize;
+        if count == 0 || count > 64 {
+            return None;
+        }
+        // FILEGROUPDESCRIPTORW is packed(1): never take field references
+        // (E0793 unaligned). Parse by byte offsets instead:
+        //   dwFlags(4) + clsid(16) + sizel(8) + pointl(8) + dwFileAttributes(4)
+        //   + 3xFILETIME(24) + nFileSizeHigh(4) + nFileSizeLow(4) = 72,
+        //   then cFileName[260] as UTF-16LE (520 bytes) => 592 per entry.
+        const NAME_OFFSET: usize = 72;
+        const NAME_LEN_U16: usize = 260;
+        const FD_SIZE: usize = 72 + 260 * 2;
+        if desc_bytes.len() < 4 + count * FD_SIZE {
+            return None;
+        }
+        let mut out = Vec::new();
+        for i in 0..count {
+            let base = 4 + i * FD_SIZE;
+            let attr = u32::from_le_bytes([
+                desc_bytes[base + 36],
+                desc_bytes[base + 37],
+                desc_bytes[base + 38],
+                desc_bytes[base + 39],
+            ]);
+            // Skip directories (FILE_ATTRIBUTE_DIRECTORY = 0x10).
+            if attr & 0x10 != 0 {
+                continue;
+            }
+            let name_off = base + NAME_OFFSET;
+            let mut wide = Vec::with_capacity(NAME_LEN_U16);
+            for k in 0..NAME_LEN_U16 {
+                let o = name_off + k * 2;
+                let c = u16::from_le_bytes([desc_bytes[o], desc_bytes[o + 1]]);
+                if c == 0 {
+                    break;
+                }
+                wide.push(c);
+            }
+            let name = String::from_utf16_lossy(&wide);
+            let name = name.trim().to_string();
+            if name.is_empty() {
+                continue;
+            }
+            // FileContents per lindex=i: try IStream then HGLOBAL.
+            if let Some(bytes) = self.get_data_bytes(data_obj, cf_contents, i as i32) {
+                out.push((name, bytes));
+            }
+        }
+        if out.is_empty() {
+            None
+        } else {
+            Some(out)
+        }
     }
 }
 
@@ -182,13 +387,10 @@ impl IDropTarget_Impl for HoldemDropTarget_Impl {
             }
 
             if let Some(dataobj) = pdataobj.as_ref() {
-                // 1. First, check for native filesystem files (CF_HDROP)
+                // 1. Real filesystem files — lossless, no copy.
                 if let Some(paths) = self.extract_files(dataobj) {
                     info!("HoldemDropTarget received {} file path(s)", paths.len());
-                    if let Some(drag_state) = self.app_handle.try_state::<Arc<DragState>>() {
-                        drag_state.successful_drop.store(true, Ordering::Relaxed);
-                        drag_state.drag_started.store(false, Ordering::Relaxed);
-                    }
+                    mark_drop(&self.app_handle);
                     if let Some(file_list) = self.app_handle.try_state::<FileList>() {
                         crate::file_drop::handle_file_drop_from_paths(
                             paths,
@@ -199,30 +401,105 @@ impl IDropTarget_Impl for HoldemDropTarget_Impl {
                     return Ok(());
                 }
 
-                // 2. Check for HTML format (images/content dragged from web browsers)
-                if let Some(html) = self.extract_html(dataobj) {
-                    if let Some(src) = parse_img_src(&html) {
-                        info!("HoldemDropTarget detected image src in dropped HTML: {}", src);
-                        if let Some(drag_state) = self.app_handle.try_state::<Arc<DragState>>() {
-                            drag_state.successful_drop.store(true, Ordering::Relaxed);
-                            drag_state.drag_started.store(false, Ordering::Relaxed);
+                // 2. Virtual files (Outlook/Discord/Slack/ZIP): FileGroupDescriptorW.
+                if let Some(virtual_files) = self.extract_virtual_files(dataobj) {
+                    info!(
+                        "HoldemDropTarget received {} virtual file(s)",
+                        virtual_files.len()
+                    );
+                    mark_drop(&self.app_handle);
+                    let app = self.app_handle.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let mut paths = Vec::new();
+                        for (name, bytes) in virtual_files {
+                            let ext = std::path::Path::new(&name)
+                                .extension()
+                                .and_then(|e| e.to_str())
+                                .unwrap_or("bin");
+                            match crate::commands::file_ops::save_bytes_to_drop_folder(
+                                &bytes, &name, ext,
+                            ) {
+                                Ok(p) => paths.push(PathBuf::from(p)),
+                                Err(e) => error!("Failed to save virtual file {}: {}", name, e),
+                            }
                         }
-                        handle_web_image_drop(src, self.app_handle.clone());
+                        if !paths.is_empty() {
+                            if let Some(file_list) = app.try_state::<FileList>() {
+                                crate::file_drop::handle_file_drop_from_paths(
+                                    paths,
+                                    file_list.inner().clone(),
+                                    app,
+                                );
+                            }
+                        }
+                    });
+                    return Ok(());
+                }
+
+                // 3. Bitmaps — prefer lossless pixels over re-downloading.
+                //    PNG format first (already encoded), then CF_DIB(V5).
+                if let Some(png_bytes) = self.extract_png_bytes(dataobj) {
+                    // Validate it actually looks like a PNG before accepting.
+                    if png_bytes.len() > 8 && &png_bytes[..8] == b"\x89PNG\r\n\x1a\n" {
+                        info!("HoldemDropTarget received PNG clipboard image");
+                        mark_drop(&self.app_handle);
+                        handle_image_bytes(
+                            png_bytes,
+                            "screenshot.png".to_string(),
+                            self.app_handle.clone(),
+                        );
+                        return Ok(());
+                    }
+                }
+                if let Some(png_bytes) = self.extract_dib_png_bytes(dataobj) {
+                    info!("HoldemDropTarget received DIB bitmap image");
+                    mark_drop(&self.app_handle);
+                    handle_image_bytes(
+                        png_bytes,
+                        "screenshot.png".to_string(),
+                        self.app_handle.clone(),
+                    );
+                    return Ok(());
+                }
+
+                // 4. HTML (browser <img> drags): all images + SourceURL referer.
+                if let Some(html) = self.extract_html_raw(dataobj) {
+                    let (srcs, referer) = parse_html_images(&html);
+                    if !srcs.is_empty() {
+                        info!(
+                            "HoldemDropTarget detected {} image(s) in dropped HTML",
+                            srcs.len()
+                        );
+                        mark_drop(&self.app_handle);
+                        handle_image_srcs(srcs, referer, self.app_handle.clone());
+                        return Ok(());
+                    }
+                    // HTML without images (rich text) — fall through to URL/text.
+                }
+
+                // 5. Explicit URL flavors (link / address-bar drags).
+                if let Some(url) = self.extract_url(dataobj) {
+                    let url = url.trim().to_string();
+                    if !url.is_empty() {
+                        info!("HoldemDropTarget detected dropped URL: {}", url);
+                        mark_drop(&self.app_handle);
+                        handle_image_srcs(vec![url], None, self.app_handle.clone());
                         return Ok(());
                     }
                 }
 
-                // 3. Check for plain text or direct URL
+                // 6. Plain text last resort.
                 if let Some(text) = self.extract_text(dataobj) {
                     let text = text.trim();
                     if !text.is_empty() {
-                        if let Some(drag_state) = self.app_handle.try_state::<Arc<DragState>>() {
-                            drag_state.successful_drop.store(true, Ordering::Relaxed);
-                            drag_state.drag_started.store(false, Ordering::Relaxed);
-                        }
+                        mark_drop(&self.app_handle);
                         if text.starts_with("http://") || text.starts_with("https://") {
-                            info!("HoldemDropTarget detected dropped URL: {}", text);
-                            handle_web_image_drop(text.to_string(), self.app_handle.clone());
+                            info!("HoldemDropTarget detected URL text: {}", text);
+                            handle_image_srcs(
+                                vec![text.to_string()],
+                                None,
+                                self.app_handle.clone(),
+                            );
                         } else {
                             info!("HoldemDropTarget saving dropped text snippet");
                             handle_text_drop(text.to_string(), self.app_handle.clone());
@@ -236,84 +513,316 @@ impl IDropTarget_Impl for HoldemDropTarget_Impl {
     }
 }
 
-pub fn register_main_drop_target(app_handle: &AppHandle, hwnd: HWND) {
+fn mark_drop(app_handle: &AppHandle) {
+    if let Some(drag_state) = app_handle.try_state::<Arc<DragState>>() {
+        drag_state.successful_drop.store(true, Ordering::Relaxed);
+        drag_state.drag_started.store(false, Ordering::Relaxed);
+    }
+}
+
+unsafe extern "system" fn enum_child_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    let vec_ptr = lparam.0 as *mut Vec<HWND>;
+    if !vec_ptr.is_null() {
+        (*vec_ptr).push(hwnd);
+    }
+    true.into()
+}
+
+fn register_on_hwnd(app_handle: &AppHandle, hwnd: HWND) {
     unsafe {
         let _ = RevokeDragDrop(hwnd);
         let target = HoldemDropTarget::new(app_handle.clone());
         let target_interface: IDropTarget = target.into();
-        let _ = RegisterDragDrop(hwnd, &target_interface);
+        if let Err(e) = RegisterDragDrop(hwnd, &target_interface) {
+            warn!("RegisterDragDrop failed for {:?}: {:?}", hwnd, e);
+        }
     }
 }
 
-fn parse_img_src(html: &str) -> Option<String> {
-    if let Some(img_idx) = html.find("<img") {
-        let after_img = &html[img_idx..];
-        if let Some(src_idx) = after_img.find("src=") {
-            let after_src = &after_img[src_idx + 4..];
-            let quote = after_src.chars().next()?;
-            if quote == '"' || quote == '\'' {
-                let rest = &after_src[1..];
-                if let Some(end_quote) = rest.find(quote) {
-                    let mut url = rest[..end_quote].replace("&amp;", "&");
-                    if url.starts_with("//") {
-                        url = format!("https:{}", url);
-                    }
-                    return Some(url);
-                }
+pub fn register_main_drop_target(app_handle: &AppHandle, hwnd: HWND) {
+    // Top-level window first…
+    register_on_hwnd(app_handle, hwnd);
+    // …then every child (WebView2 hosts its own child WidgetWin which would
+    // otherwise swallow drops before they reach us). Collect first, register
+    // after enumeration to keep the callback trivial.
+    let mut children: Vec<HWND> = Vec::new();
+    unsafe {
+        let _ = EnumChildWindows(
+            Some(hwnd),
+            Some(enum_child_proc),
+            LPARAM(&mut children as *mut Vec<HWND> as isize),
+        );
+    }
+    for child in children {
+        register_on_hwnd(app_handle, child);
+    }
+}
+
+// --- HTML parsing -----------------------------------------------------------
+
+/// Returns (all image srcs in order, optional SourceURL referer).
+/// Honors StartFragment/EndFragment offsets, decodes entities, handles
+/// //host URLs and srcset. blob: URLs are kept — the caller saves a
+/// placeholder since the backend can never resolve them.
+fn parse_html_images(html: &str) -> (Vec<String>, Option<String>) {
+    let referer = parse_html_source_url(html);
+    let (frag_start, frag_end) = parse_fragment_offsets(html);
+    let frag = &html[frag_start.min(html.len())..frag_end.min(html.len())];
+
+    let mut srcs = Vec::new();
+    let mut rest = frag;
+    // Collect every <img ... src=...> in order (multi-image drags).
+    while let Some(img_idx) = find_insensitive(rest, "<img") {
+        let after_img = &rest[img_idx..];
+        // End of this tag.
+        let tag_end = after_img.find('>').unwrap_or(after_img.len());
+        let tag = &after_img[..tag_end];
+        if let Some(src) = parse_src_attr(tag) {
+            let src = src.trim().to_string();
+            if !src.is_empty() {
+                srcs.push(normalize_img_src(&src));
+            }
+        } else if let Some(set_src) = parse_srcset_first(tag) {
+            srcs.push(normalize_img_src(&set_src));
+        }
+        rest = &after_img[tag_end.min(after_img.len())..];
+        if rest.is_empty() {
+            break;
+        }
+        // Advance past '>' to avoid re-matching the same tag.
+        if rest.starts_with('>') {
+            rest = &rest[1..];
+        }
+        if srcs.len() >= 20 {
+            break; // cap: don't materialize 100-image selections
+        }
+    }
+    (srcs, referer)
+}
+
+fn parse_html_source_url(html: &str) -> Option<String> {
+    // Header looks like: SourceURL:https://example.com/page
+    for line in html.lines().take(12) {
+        if let Some(rest) = line.strip_prefix("SourceURL:") {
+            let u = rest.trim().to_string();
+            if !u.is_empty() {
+                return Some(u);
             }
         }
     }
     None
 }
 
-fn handle_web_image_drop(src: String, app_handle: AppHandle) {
-    tauri::async_runtime::spawn(async move {
-        if src.starts_with("data:image/") {
-            if let Some(comma_pos) = src.find(',') {
-                let header = &src[..comma_pos];
-                let b64 = &src[comma_pos + 1..];
-                let ext = if header.contains("image/png") {
-                    "png"
-                } else if header.contains("image/jpeg") || header.contains("image/jpg") {
-                    "jpg"
-                } else if header.contains("image/webp") {
-                    "webp"
-                } else if header.contains("image/gif") {
-                    "gif"
-                } else if header.contains("image/svg") {
-                    "svg"
-                } else {
-                    "png"
-                };
+fn parse_fragment_offsets(html: &str) -> (usize, usize) {
+    let mut start: Option<usize> = None;
+    let mut end: Option<usize> = None;
+    for line in html.lines().take(12) {
+        if let Some(v) = line.strip_prefix("StartFragment:") {
+            start = v.trim().parse().ok();
+        } else if let Some(v) = line.strip_prefix("EndFragment:") {
+            end = v.trim().parse().ok();
+        }
+    }
+    match (start, end) {
+        (Some(s), Some(e)) if s < e && e <= html.len() => (s, e),
+        _ => (0, html.len()),
+    }
+}
 
-                if let Ok(path) = crate::commands::file_ops::save_pasted_data_base64(
-                    b64.to_string(),
-                    ext.to_string(),
-                    None,
-                ) {
-                    if let Some(file_list) = app_handle.try_state::<FileList>() {
-                        crate::file_drop::handle_file_drop_from_paths(
-                            vec![PathBuf::from(path)],
-                            file_list.inner().clone(),
-                            app_handle,
-                        );
+fn find_insensitive(haystack: &str, needle: &str) -> Option<usize> {
+    // ASCII case-insensitive search for "<img".
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    if n.len() > h.len() {
+        return None;
+    }
+    for i in 0..=h.len() - n.len() {
+        let mut ok = true;
+        for j in 0..n.len() {
+            if !h[i + j].eq_ignore_ascii_case(&n[j]) {
+                ok = false;
+                break;
+            }
+        }
+        if ok {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn parse_src_attr(tag: &str) -> Option<String> {
+    // Find src= (but not srcset= / data-src=). Scan case-insensitively.
+    let lower = tag.to_ascii_lowercase();
+    let bytes = lower.as_bytes();
+    let mut i = 0;
+    while i + 4 < bytes.len() {
+        if &bytes[i..i + 4] == b"src=" || (i + 5 <= bytes.len() && &bytes[i..i + 5] == b"src =") {
+            // Ensure preceding char isn't part of a longer name (e.g. data-src).
+            let prev_ok = if i == 0 {
+                true
+            } else {
+                let p = bytes[i - 1];
+                !(p.is_ascii_alphanumeric() || p == b'-' || p == b'_')
+            };
+            if prev_ok {
+                let orig = &tag[i..];
+                // Skip "src", spaces, '='.
+                let mut j = 3;
+                while j < orig.len() && orig.as_bytes()[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                // Handle "src =".
+                if j < orig.len() && orig.as_bytes()[j] == b'=' {
+                    j += 1;
+                } else if i + 5 <= tag.len() && tag[i..].starts_with("src =") {
+                    j = 5;
+                }
+                while j < orig.len() && orig.as_bytes()[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                let rest = &orig[j..];
+                let quote = rest.chars().next()?;
+                if quote == '"' || quote == '\'' {
+                    let inner = &rest[1..];
+                    if let Some(end) = inner.find(quote) {
+                        return Some(html_unescape(&inner[..end]));
                     }
+                    return None;
+                }
+                // Unquoted src.
+                let end = rest
+                    .find(|c: char| c.is_whitespace() || c == '>')
+                    .unwrap_or(rest.len());
+                return Some(html_unescape(rest[..end].trim()));
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn parse_srcset_first(tag: &str) -> Option<String> {
+    let lower = tag.to_ascii_lowercase();
+    let idx = lower.find("srcset=")?;
+    let mut rest = tag[idx + 7..].trim_start().to_string();
+    if rest.starts_with('=') {
+        rest = rest[1..].trim_start().to_string();
+    }
+    let quote = rest.chars().next()?;
+    let inner = if quote == '"' || quote == '\'' {
+        rest[1..].split(quote).next()?.to_string()
+    } else {
+        rest.split_whitespace().next()?.to_string()
+    };
+    // srcset: "url1 1x, url2 2x" — take first URL.
+    let first = inner.split(',').next()?.split_whitespace().next()?;
+    if first.is_empty() {
+        None
+    } else {
+        Some(html_unescape(first))
+    }
+}
+
+fn html_unescape(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+}
+
+fn normalize_img_src(src: &str) -> String {
+    if src.starts_with("//") {
+        format!("https:{}", src)
+    } else {
+        src.to_string()
+    }
+}
+
+// --- Drop handlers ----------------------------------------------------------
+
+fn handle_image_bytes(bytes: Vec<u8>, suggested_name: String, app_handle: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        match crate::commands::file_ops::save_bytes_to_drop_folder(
+            &bytes,
+            &suggested_name,
+            "png",
+        )
+        {
+            Ok(path) => {
+                if let Some(file_list) = app_handle.try_state::<FileList>() {
+                    crate::file_drop::handle_file_drop_from_paths(
+                        vec![PathBuf::from(path)],
+                        file_list.inner().clone(),
+                        app_handle,
+                    );
                 }
             }
-        } else if src.starts_with("http://") || src.starts_with("https://") {
-            match crate::commands::file_ops::download_image_to_shelf(src).await {
-                Ok(path) => {
-                    if let Some(file_list) = app_handle.try_state::<FileList>() {
-                        crate::file_drop::handle_file_drop_from_paths(
-                            vec![PathBuf::from(path)],
-                            file_list.inner().clone(),
-                            app_handle,
-                        );
+            Err(e) => error!("Failed to save dropped image bytes: {}", e),
+        }
+    });
+}
+
+fn handle_image_srcs(srcs: Vec<String>, referer: Option<String>, app_handle: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let mut paths = Vec::new();
+        for src in srcs {
+            if src.starts_with("data:image/") {
+                if let Some(comma) = src.find(',') {
+                    let header = &src[..comma];
+                    let b64 = &src[comma + 1..];
+                    let ext = if header.contains("image/png") {
+                        "png"
+                    } else if header.contains("image/jpeg") || header.contains("image/jpg") {
+                        "jpg"
+                    } else if header.contains("image/webp") {
+                        "webp"
+                    } else if header.contains("image/gif") {
+                        "gif"
+                    } else if header.contains("image/svg") {
+                        "svg"
+                    } else {
+                        "png"
+                    };
+                    match crate::commands::file_ops::save_pasted_data_base64(
+                        b64.to_string(),
+                        ext.to_string(),
+                        None,
+                    ) {
+                        Ok(p) => paths.push(PathBuf::from(p)),
+                        Err(e) => error!("Failed to save data: URL image: {}", e),
                     }
                 }
-                Err(e) => {
-                    error!("Failed to download dropped web image: {}", e);
+            } else if src.starts_with("blob:") {
+                // Backend cannot resolve blob: — save placeholder; the thin
+                // frontend forwarder handles the real bytes when it can.
+                match crate::commands::file_ops::save_url_placeholder(&src) {
+                    Ok(p) => paths.push(PathBuf::from(p)),
+                    Err(e) => error!("Failed to save blob placeholder: {}", e),
                 }
+            } else if src.starts_with("http://") || src.starts_with("https://") {
+                match crate::commands::file_ops::download_image_to_shelf(
+                    src,
+                    referer.clone(),
+                )
+                .await
+                {
+                    Ok(p) => paths.push(PathBuf::from(p)),
+                    Err(e) => error!("Failed to download dropped web image: {}", e),
+                }
+            } else {
+                warn!("Ignoring unsupported dropped image src");
+            }
+        }
+        if !paths.is_empty() {
+            if let Some(file_list) = app_handle.try_state::<FileList>() {
+                crate::file_drop::handle_file_drop_from_paths(
+                    paths,
+                    file_list.inner().clone(),
+                    app_handle,
+                );
             }
         }
     });
@@ -321,7 +830,8 @@ fn handle_web_image_drop(src: String, app_handle: AppHandle) {
 
 fn handle_text_drop(text: String, app_handle: AppHandle) {
     tauri::async_runtime::spawn(async move {
-        if let Ok(path) = crate::commands::file_ops::save_pasted_text(text, "txt".to_string(), None) {
+        if let Ok(path) = crate::commands::file_ops::save_pasted_text(text, "txt".to_string(), None)
+        {
             if let Some(file_list) = app_handle.try_state::<FileList>() {
                 crate::file_drop::handle_file_drop_from_paths(
                     vec![PathBuf::from(path)],
@@ -331,4 +841,150 @@ fn handle_text_drop(text: String, app_handle: AppHandle) {
             }
         }
     });
+}
+
+// --- DIB -> PNG -------------------------------------------------------------
+
+/// Convert raw CF_DIB(V5) bytes (BITMAPINFOHEADER + pixels) to PNG bytes.
+/// Supports the common screenshot cases: 32-bit and 24-bit BI_RGB/BI_BITFIELDS.
+/// Returns None for paletted/compressed formats (caller falls through).
+fn dib_bytes_to_png(dib: &[u8]) -> Option<Vec<u8>> {
+    if dib.len() < 40 {
+        return None;
+    }
+    let read_u32 = |o: usize| u32::from_le_bytes([dib[o], dib[o + 1], dib[o + 2], dib[o + 3]]);
+    let read_i32 = |o: usize| i32::from_le_bytes([dib[o], dib[o + 1], dib[o + 2], dib[o + 3]]);
+    let read_u16 = |o: usize| u16::from_le_bytes([dib[o], dib[o + 1]]);
+
+    let header_size = read_u32(0) as usize;
+    if header_size < 40 || header_size > dib.len() {
+        return None;
+    }
+    let width = read_i32(4);
+    let height_raw = read_i32(8);
+    let planes = read_u16(12);
+    let bit_count = read_u16(14);
+    let compression = read_u32(16);
+
+    if width <= 0 || width > 16384 || height_raw == 0 || height_raw.abs() > 16384 {
+        return None;
+    }
+    if planes != 1 {
+        return None;
+    }
+    // BI_RGB=0, BI_BITFIELDS=3. Others (RLE, PNG-in-DIB, etc.) unsupported.
+    if compression != 0 && compression != 3 {
+        return None;
+    }
+    let width_u = width as u32;
+    let height_u = height_raw.unsigned_abs();
+    let top_down = height_raw < 0;
+
+    // Palette size for <=8bpp — we don't support paletted, bail early.
+    if bit_count <= 8 {
+        return None;
+    }
+
+    // For BI_BITFIELDS with 16/32bpp there are 3 color masks after the header.
+    let masks_len = if compression == 3 && (bit_count == 16 || bit_count == 32) {
+        12
+    } else {
+        0
+    };
+    let pixels_offset = header_size + masks_len;
+    if pixels_offset >= dib.len() {
+        return None;
+    }
+
+    // Stride is DWORD-aligned.
+    let stride = (width_u as usize * bit_count as usize).div_ceil(32) * 4;
+    let needed = stride.checked_mul(height_u as usize)?;
+    if dib.len() < pixels_offset + needed {
+        return None;
+    }
+
+    let mut rgba = Vec::with_capacity((width_u * height_u * 4) as usize);
+    match bit_count {
+        32 => {
+            for row in 0..height_u as usize {
+                let src_row = if top_down {
+                    row
+                } else {
+                    height_u as usize - 1 - row
+                };
+                let base = pixels_offset + src_row * stride;
+                for col in 0..width_u as usize {
+                    let o = base + col * 4;
+                    let b = dib[o];
+                    let g = dib[o + 1];
+                    let r = dib[o + 2];
+                    let a = dib[o + 3];
+                    rgba.extend_from_slice(&[r, g, b, a]);
+                }
+            }
+        }
+        24 => {
+            for row in 0..height_u as usize {
+                let src_row = if top_down {
+                    row
+                } else {
+                    height_u as usize - 1 - row
+                };
+                let base = pixels_offset + src_row * stride;
+                for col in 0..width_u as usize {
+                    let o = base + col * 3;
+                    let b = dib[o];
+                    let g = dib[o + 1];
+                    let r = dib[o + 2];
+                    rgba.extend_from_slice(&[r, g, b, 255]);
+                }
+            }
+        }
+        _ => return None,
+    }
+
+    let img = image::RgbaImage::from_raw(width_u, height_u, rgba)?;
+    let dyn_img = image::DynamicImage::ImageRgba8(img);
+    let mut png = Vec::new();
+    {
+        use std::io::Cursor;
+        let mut cursor = Cursor::new(&mut png);
+        dyn_img
+            .write_to(&mut cursor, image::ImageFormat::Png)
+            .ok()?;
+    }
+    if png.is_empty() {
+        None
+    } else {
+        Some(png)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_single_img_src_with_entities() {
+        let html = "Version:0.9\r\nStartFragment:00000080\r\nEndFragment:00000200\r\nSourceURL:https://example.com/p\r\n<html><body><!--StartFragment--><img src=\"https://example.com/a.png?x=1&amp;y=2\"><!--EndFragment--></body></html>";
+        let (srcs, referer) = parse_html_images(html);
+        assert_eq!(srcs.len(), 1);
+        assert!(srcs[0].contains("x=1&y=2"));
+        assert_eq!(referer.as_deref(), Some("https://example.com/p"));
+    }
+
+    #[test]
+    fn collects_multiple_img_srcs() {
+        let html = "<img src=\"https://a.com/1.png\"><p>x</p><IMG SRC='https://b.com/2.jpg'>";
+        let (srcs, _) = parse_html_images(html);
+        assert_eq!(srcs.len(), 2);
+    }
+
+    #[test]
+    fn normalizes_protocol_relative() {
+        assert_eq!(
+            normalize_img_src("//cdn.com/x.png"),
+            "https://cdn.com/x.png"
+        );
+    }
 }

--- a/app/src-tauri/src/file.rs
+++ b/app/src-tauri/src/file.rs
@@ -1,6 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::fs;
-use std::io;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -12,24 +10,7 @@ pub struct FileMetadata {
     pub file_type: String,
 }
 
-// Calculate the size of a directory by recursively summing all file sizes
-pub fn get_dir_size(path: &PathBuf) -> io::Result<u64> {
-    let mut total_size = 0;
-
-    if path.is_dir() {
-        for entry in fs::read_dir(path)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            if path.is_dir() {
-                if let Ok(size) = get_dir_size(&path) {
-                    total_size += size;
-                }
-            } else if let Ok(metadata) = fs::metadata(&path) {
-                total_size += metadata.len();
-            }
-        }
-    }
-
-    Ok(total_size)
-}
+// Folder sizes are intentionally not computed: directory drops store size 0
+// and the UI shows them as folders. This keeps drops instant even for huge
+// trees (node_modules, photo libraries) and avoids recursive I/O on the
+// drop hot path.

--- a/app/src-tauri/src/file_drop.rs
+++ b/app/src-tauri/src/file_drop.rs
@@ -51,7 +51,13 @@ pub fn handle_file_drop_from_paths(
         }
 
         // Now lock and add to list
-        let mut list = file_list.lock().unwrap();
+        let Ok(mut list) = file_list.lock() else {
+            error!(
+                "file_drop: FileList mutex poisoned, dropping {} path(s)",
+                paths.len()
+            );
+            return;
+        };
         let starting_id = list.len() as u64;
 
         for (i, mut file) in new_files.into_iter().enumerate() {

--- a/app/src-tauri/src/file_drop.rs
+++ b/app/src-tauri/src/file_drop.rs
@@ -1,4 +1,4 @@
-use crate::file::{get_dir_size, FileMetadata};
+use crate::file::FileMetadata;
 use crate::FileList;
 use std::path::PathBuf;
 use tauri::{AppHandle, Emitter};
@@ -19,9 +19,10 @@ pub fn handle_file_drop_from_paths(
                     // Keep the original reference. Dropping a file must never copy it.
                     let final_path = path.clone();
 
-                    // Calculate size correctly for directories
+                    // Directories store size 0 (no recursive walk — see file.rs).
+                    // This keeps drops instant for huge folders.
                     let size = if metadata.is_dir() {
-                        get_dir_size(path).unwrap_or(0)
+                        0
                     } else {
                         metadata.len()
                     };

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex;
-use tauri::{DragDropEvent, Manager, PhysicalPosition, WebviewUrl, WebviewWindowBuilder, WindowEvent};
+use tauri::{Manager, PhysicalPosition, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_updater::UpdaterExt;
 use tracing::{error, info, warn};
 use windows::Win32::Foundation::{POINT, WAIT_OBJECT_0};
@@ -246,33 +246,6 @@ fn build_app() -> tauri::Builder<tauri::Wry> {
             }
 
             Ok(())
-        })
-        .on_window_event(|window, event| {
-            if let WindowEvent::DragDrop(drop_event) = event {
-                let drag_state = window.app_handle().state::<Arc<DragState>>().inner();
-                match drop_event {
-                    DragDropEvent::Enter { .. } => {
-                        drag_state.drag_started.store(true, Ordering::Relaxed);
-                    }
-                    DragDropEvent::Drop { paths, .. } => {
-                        info!("Received {} dropped file(s) in the app window", paths.len());
-                        drag_state.successful_drop.store(true, Ordering::Relaxed);
-                        drag_state.drag_started.store(false, Ordering::Relaxed);
-
-                        // Handle the file drop
-                        let app_handle = window.app_handle();
-                        let file_list_state = app_handle.state::<FileList>();
-                        file_drop::handle_file_drop_from_paths(
-                            paths.clone(),
-                            file_list_state.inner().clone(),
-                            app_handle.clone(),
-                        );
-
-                        // Do not hide the window after processing - let user interact with the files
-                    }
-                    _ => {}
-                }
-            }
         })
 }
 

--- a/app/src-tauri/src/thumbnail.rs
+++ b/app/src-tauri/src/thumbnail.rs
@@ -16,8 +16,8 @@ use thiserror::Error;
 use windows::core::HSTRING;
 use windows::Win32::Foundation::SIZE;
 use windows::Win32::Graphics::Gdi::{
-    CreateCompatibleDC, DeleteDC, DeleteObject, GetDIBits, GetObjectW, SelectObject, BITMAP,
-    BITMAPINFO, BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HBITMAP, HDC, HGDIOBJ,
+    CreateCompatibleDC, DeleteDC, DeleteObject, GetDIBits, GetObjectW, BITMAP, BITMAPINFO,
+    BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HBITMAP, HDC, HGDIOBJ,
 };
 use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
 use windows::Win32::UI::Shell::{IShellItemImageFactory, SHCreateItemFromParsingName, SIIGBF};
@@ -42,10 +42,9 @@ pub enum ThumbnailError {
 /// Generate a base64-encoded PNG thumbnail for any file type the OS can
 /// preview. Returns the file-type icon (as Explorer shows) when no thumbnail
 /// provider is registered.
-pub fn get_thumbnail_base64(file_path: &str) -> Result<String, String> {
-    let path: &Path = Path::new(file_path);
+pub fn get_thumbnail_base64(path: &Path) -> Result<String, String> {
     if !path.exists() {
-        return Err(ThumbnailError::FileNotFound(file_path.to_string()).to_string());
+        return Err(ThumbnailError::FileNotFound(path.display().to_string()).to_string());
     }
     let (rgba, width, height): (Vec<u8>, u32, u32) =
         generate_thumbnail(path).map_err(|e: ThumbnailError| e.to_string())?;
@@ -137,8 +136,22 @@ fn hbitmap_to_rgba(hbitmap: HBITMAP) -> Result<(Vec<u8>, u32, u32), ThumbnailErr
         );
     }
 
+    // BITMAP dims come from the shell provider — validate before the
+    // w*h*4 allocation so corrupt data can't OOM/abort the app.
+    // Note: negative bmWidth/bmHeight must be rejected before `as u32`
+    // (a direct cast wraps to ~4B).
+    if bitmap.bmWidth <= 0 || bitmap.bmHeight <= 0 {
+        return Err(ThumbnailError::GenerationFailed(
+            "Invalid bitmap dimensions".to_string(),
+        ));
+    }
     let width: u32 = bitmap.bmWidth as u32;
     let height: u32 = bitmap.bmHeight as u32;
+    if width == 0 || height == 0 || width > 2048 || height > 2048 {
+        return Err(ThumbnailError::GenerationFailed(
+            "Suspicious bitmap dimensions".to_string(),
+        ));
+    }
 
     let dc: HDC = unsafe { CreateCompatibleDC(None) };
     if dc == HDC::default() {
@@ -147,8 +160,9 @@ fn hbitmap_to_rgba(hbitmap: HBITMAP) -> Result<(Vec<u8>, u32, u32), ThumbnailErr
         ));
     }
 
-    let old_obj = unsafe { SelectObject(dc, hbitmap.into()) };
-
+    // NOTE: the bitmap must NOT be selected into the DC for GetDIBits —
+    // MS docs say the call may fail (return 0) otherwise. The screen-compatible
+    // DC is only needed for color conversion of non-DIB sources.
     let mut bmi: BITMAPINFO = BITMAPINFO {
         bmiHeader: BITMAPINFOHEADER {
             biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
@@ -162,8 +176,13 @@ fn hbitmap_to_rgba(hbitmap: HBITMAP) -> Result<(Vec<u8>, u32, u32), ThumbnailErr
         ..Default::default()
     };
 
-    let pixel_count: usize = (width as usize) * (height as usize);
-    let mut buffer: Vec<u8> = vec![0u8; pixel_count * 4];
+    let pixel_count: usize = (width as usize)
+        .checked_mul(height as usize)
+        .ok_or_else(|| ThumbnailError::GenerationFailed("Bitmap too large".to_string()))?;
+    let buf_len = pixel_count
+        .checked_mul(4)
+        .ok_or_else(|| ThumbnailError::GenerationFailed("Bitmap too large".to_string()))?;
+    let mut buffer: Vec<u8> = vec![0u8; buf_len];
 
     let lines: i32 = unsafe {
         GetDIBits(
@@ -178,7 +197,6 @@ fn hbitmap_to_rgba(hbitmap: HBITMAP) -> Result<(Vec<u8>, u32, u32), ThumbnailErr
     };
 
     unsafe {
-        SelectObject(dc, old_obj);
         let _ = DeleteDC(dc);
     }
 

--- a/app/src-tauri/src/thumbnail.rs
+++ b/app/src-tauri/src/thumbnail.rs
@@ -1,18 +1,244 @@
+//! Windows thumbnail extraction using the Shell API.
+//!
+//! In-house replacement for the `thumb-rs` git dependency. Uses the same API
+//! Explorer.exe calls (`IShellItemImageFactory::GetImage`), so output is
+//! identical: real thumbnails when a provider exists (images, video, PDF,
+//! Office docs), file-type icons as fallback.
+//!
+//! Holdem is Windows-only, so only the Windows backend is ported. Thumbnail
+//! size is fixed at 256x256 — the only size any caller ever used
+//! (`ThumbnailScale::default()`).
+
 use base64::{engine::general_purpose, Engine as _};
 use image::{ImageBuffer, Rgba};
-use thumb_rs::{get_thumbnail, ThumbnailScale};
+use std::path::Path;
+use thiserror::Error;
+use windows::core::HSTRING;
+use windows::Win32::Foundation::SIZE;
+use windows::Win32::Graphics::Gdi::{
+    CreateCompatibleDC, DeleteDC, DeleteObject, GetDIBits, GetObjectW, SelectObject, BITMAP,
+    BITMAPINFO, BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HBITMAP, HDC, HGDIOBJ,
+};
+use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
+use windows::Win32::UI::Shell::{IShellItemImageFactory, SHCreateItemFromParsingName, SIIGBF};
 
+/// Maximum thumbnail dimension in pixels (square).
+const THUMB_PX: i32 = 256;
+
+/// Errors from thumbnail generation. Mapped to `String` at the Tauri command
+/// boundary (`get_thumbnail_base64`), which must return `Result<_, String>`.
+#[derive(Error, Debug)]
+pub enum ThumbnailError {
+    #[error("File not found: {0}")]
+    FileNotFound(String),
+
+    #[error("Thumbnail generation failed: {0}")]
+    GenerationFailed(String),
+
+    #[error("Platform error: {0}")]
+    PlatformError(String),
+}
+
+/// Generate a base64-encoded PNG thumbnail for any file type the OS can
+/// preview. Returns the file-type icon (as Explorer shows) when no thumbnail
+/// provider is registered.
 pub fn get_thumbnail_base64(file_path: &str) -> Result<String, String> {
-    let thumb = get_thumbnail(file_path, ThumbnailScale::default()).map_err(|e| e.to_string())?;
-    let img = ImageBuffer::<Rgba<u8>, _>::from_raw(thumb.width, thumb.height, thumb.rgba)
-        .ok_or_else(|| "Failed to create image buffer".to_string())?;
-    let mut png_data = Vec::new();
+    let path: &Path = Path::new(file_path);
+    if !path.exists() {
+        return Err(ThumbnailError::FileNotFound(file_path.to_string()).to_string());
+    }
+    let (rgba, width, height): (Vec<u8>, u32, u32) =
+        generate_thumbnail(path).map_err(|e: ThumbnailError| e.to_string())?;
+    let img: ImageBuffer<Rgba<u8>, Vec<u8>> =
+        ImageBuffer::<Rgba<u8>, _>::from_raw(width, height, rgba)
+            .ok_or_else(|| "Failed to create image buffer".to_string())?;
+    let mut png_data: Vec<u8> = Vec::new();
     img.write_to(
         &mut std::io::Cursor::new(&mut png_data),
         image::ImageFormat::Png,
     )
     .map_err(|e| e.to_string())?;
-    let encoded = general_purpose::STANDARD.encode(&png_data);
+    Ok(general_purpose::STANDARD.encode(&png_data))
+}
 
-    Ok(encoded)
+/// Generate raw RGBA8 pixels via `IShellItemImageFactory::GetImage`.
+///
+/// Uses default flags (`SIIGBF(0)` = `SIIGBF_RESIZETOFIT`), matching Explorer:
+/// real thumbnails when available, icons as fallback. Do NOT switch to
+/// `SIIGBF_THUMBNAILONLY` — most documents would start erroring.
+fn generate_thumbnail(file_path: &Path) -> Result<(Vec<u8>, u32, u32), ThumbnailError> {
+    let path_str: &str = file_path.to_str().ok_or_else(|| {
+        ThumbnailError::PlatformError("Invalid UTF-8 in file path".to_string())
+    })?;
+    let wide_path: HSTRING = HSTRING::from(path_str);
+
+    // Required for COM. Per-call init is correct: Tauri runs commands on a
+    // thread pool, so this must not be hoisted to `setup`.
+    let hr: windows::core::HRESULT = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+    if hr.is_err() {
+        return Err(ThumbnailError::PlatformError(format!(
+            "CoInitializeEx failed: {hr:?}"
+        )));
+    }
+
+    let shell_item: IShellItemImageFactory =
+        match unsafe { SHCreateItemFromParsingName(&wide_path, None) } {
+            Ok(item) => item,
+            Err(e) => {
+                unsafe { CoUninitialize() };
+                // 0x80070002 = ERROR_FILE_NOT_FOUND, 0x80070003 = ERROR_PATH_NOT_FOUND
+                let code: u32 = e.code().0 as u32;
+                if code == 0x80070002 || code == 0x80070003 {
+                    return Err(ThumbnailError::FileNotFound(
+                        file_path.display().to_string(),
+                    ));
+                }
+                return Err(ThumbnailError::PlatformError(format!(
+                    "SHCreateItemFromParsingName failed: {e}"
+                )));
+            }
+        };
+
+    let hbitmap: HBITMAP = match get_hbitmap(&shell_item) {
+        Ok(h) => h,
+        Err(e) => {
+            unsafe { CoUninitialize() };
+            return Err(e);
+        }
+    };
+
+    let result: Result<(Vec<u8>, u32, u32), ThumbnailError> = hbitmap_to_rgba(hbitmap);
+
+    unsafe {
+        let _ = DeleteObject(hbitmap.into());
+        CoUninitialize();
+    }
+
+    result
+}
+
+fn get_hbitmap(shell_item: &IShellItemImageFactory) -> Result<HBITMAP, ThumbnailError> {
+    let dimensions: SIZE = SIZE {
+        cx: THUMB_PX,
+        cy: THUMB_PX,
+    };
+    unsafe { shell_item.GetImage(dimensions, SIIGBF(0)) }
+        .map_err(|e| ThumbnailError::GenerationFailed(format!("GetImage failed: {e}")))
+}
+
+/// Extract RGBA8 from an `HBITMAP` via GDI.
+fn hbitmap_to_rgba(hbitmap: HBITMAP) -> Result<(Vec<u8>, u32, u32), ThumbnailError> {
+    let mut bitmap: BITMAP = BITMAP::default();
+    unsafe {
+        GetObjectW(
+            HGDIOBJ(hbitmap.0),
+            std::mem::size_of::<BITMAP>() as i32,
+            Some(&mut bitmap as *mut _ as *mut _),
+        );
+    }
+
+    let width: u32 = bitmap.bmWidth as u32;
+    let height: u32 = bitmap.bmHeight as u32;
+
+    let dc: HDC = unsafe { CreateCompatibleDC(None) };
+    if dc == HDC::default() {
+        return Err(ThumbnailError::PlatformError(
+            "CreateCompatibleDC failed".to_string(),
+        ));
+    }
+
+    let old_obj = unsafe { SelectObject(dc, hbitmap.into()) };
+
+    let mut bmi: BITMAPINFO = BITMAPINFO {
+        bmiHeader: BITMAPINFOHEADER {
+            biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+            biWidth: width as i32,
+            biHeight: height as i32, // positive = bottom-up
+            biPlanes: 1,
+            biBitCount: 32,
+            biCompression: BI_RGB.0,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let pixel_count: usize = (width as usize) * (height as usize);
+    let mut buffer: Vec<u8> = vec![0u8; pixel_count * 4];
+
+    let lines: i32 = unsafe {
+        GetDIBits(
+            dc,
+            hbitmap,
+            0,
+            height,
+            Some(buffer.as_mut_ptr() as *mut _),
+            &mut bmi,
+            DIB_RGB_COLORS,
+        )
+    };
+
+    unsafe {
+        SelectObject(dc, old_obj);
+        let _ = DeleteDC(dc);
+    }
+
+    if lines == 0 {
+        return Err(ThumbnailError::GenerationFailed(
+            "GetDIBits returned 0 lines".to_string(),
+        ));
+    }
+
+    swap_bgra_to_rgba(&mut buffer);
+    let flipped: Vec<u8> = flip_rows_bottom_up(&buffer, width, height);
+
+    Ok((flipped, width, height))
+}
+
+/// `GetDIBits` returns BGRA; PNG/`image` wants RGBA. Pure for testability.
+fn swap_bgra_to_rgba(buffer: &mut [u8]) {
+    for pixel in buffer.chunks_exact_mut(4) {
+        pixel.swap(0, 2);
+    }
+}
+
+/// `GetDIBits` returns rows bottom-up; callers want top-down. Pure for
+/// testability.
+fn flip_rows_bottom_up(buffer: &[u8], width: u32, height: u32) -> Vec<u8> {
+    let row_bytes: usize = (width as usize) * 4;
+    let mut flipped: Vec<u8> = vec![0u8; buffer.len()];
+    for row in 0..height as usize {
+        let src: usize = row * row_bytes;
+        let dst: usize = (height as usize - 1 - row) * row_bytes;
+        flipped[dst..dst + row_bytes].copy_from_slice(&buffer[src..src + row_bytes]);
+    }
+    flipped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_swap_bgra_to_rgba() {
+        let mut buf: Vec<u8> = vec![10, 20, 30, 255, 1, 2, 3, 128];
+        swap_bgra_to_rgba(&mut buf);
+        assert_eq!(buf, vec![30, 20, 10, 255, 3, 2, 1, 128]);
+    }
+
+    #[test]
+    fn test_flip_rows_bottom_up() {
+        // 2x2 image, one row = 8 bytes. Row 0 is bottom, row 1 is top.
+        let bottom: Vec<u8> = vec![1, 1, 1, 255, 2, 2, 2, 255];
+        let top: Vec<u8> = vec![3, 3, 3, 255, 4, 4, 4, 255];
+        let buffer: Vec<u8> = [bottom.clone(), top.clone()].concat();
+        let flipped: Vec<u8> = flip_rows_bottom_up(&buffer, 2, 2);
+        assert_eq!(flipped, [top, bottom].concat());
+    }
+
+    #[test]
+    fn test_thumbnail_error_display() {
+        let e: ThumbnailError =
+            ThumbnailError::FileNotFound("C:\\missing.txt".to_string());
+        assert_eq!(e.to_string(), "File not found: C:\\missing.txt");
+    }
 }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
         "title": "holdem",
         "width": 165,
         "height": 175,
-        "dragDropEnabled": true,
+        "dragDropEnabled": false,
         "decorations": false,
         "transparent": false,
         "focus": false,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,7 +7,6 @@ import { closeWindow } from "@/lib/windowUtils";
 import { FileWithPath } from "@/types";
 import { DialogClose } from "@radix-ui/react-dialog";
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { ChevronDown, Download, Settings, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -47,25 +46,14 @@ function App() {
     if (listenerSetup.current) return;
     listenerSetup.current = true;
     let cancelled = false;
-    let unlistenWebview: (() => void) | undefined;
     let unlistenNavigate: (() => void) | undefined;
 
-    const setupFileListener = async () => {
-      const webview = await getCurrentWebview();
-      const fn = await webview.onDragDropEvent(async (event) => {
-        if (event.payload.type === 'drop') {
-          invoke('mark_drop_received').catch(() => {});
-          droppedFiles();
-        }
-      });
-      if (cancelled) {
-        fn();
-      } else {
-        unlistenWebview = fn;
-      }
-    };
-
-    setupFileListener();
+    // Drops are owned by the native HoldemDropTarget (see
+    // src-tauri/src/drop_target.rs). The frontend only forwards blob-backed
+    // virtual files that the backend can never resolve (blob: URLs are
+    // opaque to reqwest by design). Everything else — real paths, HTML,
+    // URLs, plain text, bitmaps, FileGroupDescriptor virtual files — is
+    // handled natively and arrives via the `files_updated` event.
 
     // Set up navigation event listener
     const unlisten = listen<string>("navigate_to", (event) => {
@@ -84,13 +72,12 @@ function App() {
     return () => {
       cancelled = true;
       unlisten.then(fn => fn());
-      if (unlistenWebview) unlistenWebview();
       if (unlistenNavigate) unlistenNavigate();
       // Reset the guard so a re-run (e.g. StrictMode remount) re-registers
       // listeners instead of exiting early while they stay removed.
       listenerSetup.current = false;
     };
-  }, [navigate, droppedFiles]);
+  }, [navigate]);
 
   const handleDragEnter = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -108,43 +95,39 @@ function App() {
     e.dataTransfer.dropEffect = 'copy';
   }, []);
 
+  // Thin forwarder only: backend owns all drops EXCEPT blob-backed virtual
+  // files (browser canvas / Discord / blob:<uuid>), which reqwest can never
+  // resolve. Those arrive here as File objects WITHOUT a .path — read them
+  // via FileReader and hand the bytes to the backend. Everything else
+  // returns early so the same physical drop is never processed twice.
   const handleDrop = useCallback(async (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    invoke('mark_drop_received').catch(() => {});
 
-    const nativeFiles = Array.from(e.dataTransfer.files);
-    const validPaths: string[] = [];
-    const virtualFiles: File[] = [];
+    const files = Array.from(e.dataTransfer.files);
+    const virtualFiles = files.filter((f) => !(f as FileWithPath).path);
 
-    nativeFiles.forEach((file) => {
-      const path = (file as FileWithPath).path;
-      if (path) {
-        validPaths.push(path);
-      } else {
-        virtualFiles.push(file);
-      }
-    });
-
-    if (validPaths.length > 0) {
-      invoke('add_files', { files: validPaths })
-        .then(() => droppedFiles())
-        .catch((err) => console.error('Failed to add dropped files', err));
+    if (virtualFiles.length === 0) {
+      // Real files, HTML, URLs, text, bitmaps, FileGroupDescriptor drops:
+      // the native drop target already shelved them. Just refresh.
+      droppedFiles();
       return;
     }
 
-    if (virtualFiles.length > 0) {
-      for (const file of virtualFiles) {
-        const reader = new FileReader();
+    invoke('mark_drop_received').catch(() => {});
+    for (const file of virtualFiles) {
+      const reader = new FileReader();
+      const done = new Promise<void>((resolve) => {
         reader.onload = async () => {
-          const base64Data = (reader.result as string).split(',')[1];
-          let extension = 'png';
-          if (file.name && file.name.includes('.')) {
-            extension = file.name.split('.').pop()?.toLowerCase() || 'png';
-          } else if (file.type) {
-            extension = file.type.split('/')[1] || 'png';
-          }
           try {
+            const result = reader.result as string;
+            const base64Data = result.includes(',') ? result.split(',')[1] : result;
+            let extension = 'png';
+            if (file.name && file.name.includes('.')) {
+              extension = file.name.split('.').pop()?.toLowerCase() || 'png';
+            } else if (file.type) {
+              extension = file.type.split('/')[1] || 'png';
+            }
             const path = await invoke<string>('save_pasted_data_base64', {
               dataBase64: base64Data,
               extension,
@@ -153,60 +136,17 @@ function App() {
             await invoke('add_files', { files: [path] });
             droppedFiles();
           } catch (err) {
-            console.error('Failed to save dropped virtual file', err);
+            console.error('Failed to save dropped virtual (blob) file', err);
           }
+          resolve();
         };
-        reader.readAsDataURL(file);
-      }
-      return;
-    }
-
-    // In-webview HTML / text drops fallback
-    const html = e.dataTransfer.getData("text/html");
-    if (html) {
-      const match = html.match(/<img.*?src=["'](.*?)["']/i);
-      if (match && match[1]) {
-        const src = match[1];
-        if (src.startsWith('data:image/')) {
-          const base64Data = src.split(',')[1];
-          try {
-            const path = await invoke<string>('save_pasted_data_base64', {
-              dataBase64: base64Data,
-              extension: 'png',
-              originalName: null,
-            });
-            await invoke('add_files', { files: [path] });
-            droppedFiles();
-          } catch (err) {
-            console.error('Failed to save dropped base64 image', err);
-          }
-          return;
-        } else {
-          try {
-            const path = await invoke<string>('download_image_to_shelf', { url: src });
-            await invoke('add_files', { files: [path] });
-            droppedFiles();
-            return;
-          } catch (err) {
-            console.error('Failed to fetch and save dropped image URL', err);
-          }
-        }
-      }
-    }
-
-    const textData = e.dataTransfer.getData("text/plain") || e.dataTransfer.getData("text");
-    if (textData) {
-      try {
-        const path = await invoke<string>('save_pasted_text', {
-          text: textData,
-          extension: 'txt',
-          originalName: null,
-        });
-        await invoke('add_files', { files: [path] });
-        droppedFiles();
-      } catch (err) {
-        console.error('Failed to drop text', err);
-      }
+        reader.onerror = () => {
+          console.error('Failed to read dropped virtual file', reader.error);
+          resolve();
+        };
+      });
+      reader.readAsDataURL(file);
+      await done;
     }
   }, [droppedFiles]);
 


### PR DESCRIPTION
Three stacked commits:

## feat(drops): universal native drop target, no folder-size walks

- Native `IDropTarget` replaces Tauri drag-drop events (`dragDropEnabled` off).
- Virtual files (`FileGroupDescriptor`), bitmaps (`CF_DIB`/`PNG`) and web images land in a dated drop folder with unique timestamp+rand names.
- Folder drops store size 0 instead of recursive walks — huge trees stay instant.

## refactor(thumbnails): vendor thumb-rs Windows backend in-house

- Drops the unpinned `thumb-rs` git dependency; ports its `IShellItemImageFactory` backend into `thumbnail.rs` (fixed 256px, `thiserror` `ThumbnailError`, 3 unit tests).
- `cargo check` / `clippy -D warnings` / `cargo test` (6/6) green.

## ci: auto-review PRs with opencode bot

- New `.github/workflows/opencode-review.yml`: official opencode action, model `opencode/muse-spark-1.3-contributor-free` at `xhigh` reasoning.
- Needs repo secret `OPENCODE_API_KEY` (Zen, free tier). Optional `OPENCODE_APP_ID` + `OPENCODE_APP_PRIVATE_KEY` for `opencode[bot]` identity + avatar, else falls back to `github-actions[bot]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded Windows drag-and-drop support for files, virtual files, images, HTML content, URLs, and text.
  - Added support for saving full base64 data URLs and downloaded images, with URL placeholders when direct downloads are unavailable.
  - Improved Windows thumbnail generation for files and folders.

- **Bug Fixes**
  - Prevented filename conflicts and unsafe control characters in saved items.
  - Folder drops now process faster without recursively calculating folder sizes.
  - Added safeguards for oversized, invalid, or unsupported image downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->