### PR TITLE
Release v3.2.0

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -3,7 +3,8 @@ name: Tauri Build and Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*.*.*'
+      - '[0-9]*.[0-9]*.[0-9]*'
 
 permissions:
   contents: write
@@ -55,10 +56,36 @@ jobs:
           tagName: ${{ github.ref_name }}
           projectPath: app
           args: --target ${{ matrix.target }}
-          releaseName: "Holdem v__VERSION__"
-          releaseBody: "See the release assets for this version."
+          releaseName: 'Holdem __VERSION__'
+          releaseBody: 'See the release assets below and the full notes at https://holdem.iamzub.in/changelog.'
           releaseDraft: false
           prerelease: false
+
+  publish-notes:
+    # Replaces the placeholder body with the matching CHANGELOG.md section,
+    # so `CHANGELOG.md` stays the single source of truth for release notes.
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository (tag)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Update release notes from CHANGELOG.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.ref_name }}"
+          ver="${tag#v}"
+          awk "/^## \[$ver\]/{flag=1;next}/^## \[/{flag=0}flag" CHANGELOG.md > notes.md
+          if [ ! -s notes.md ]; then
+            echo "No CHANGELOG.md entry for $tag; keeping default body."
+            exit 0
+          fi
+          gh release edit "$tag" \
+            --repo "${{ github.repository }}" \
+            --notes-file notes.md
 
   sync-update-json-to-website:
     needs: release

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ﻿# Keys and secrets
-key.txt
+key.txt*
 *.key
 *.sig
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "thumb-rs"]
-	path = thumb-rs
-	url = https://github.com/iamzubin/thumb-rs.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to Holdem are documented here. The desktop app follows
+SemVer (`3.x.y` tags, no `v` prefix). Website copy that only references the
+current version lives in `holdem_website/`; the updater manifest
+(`holdem_website/public/update.json`) is synced automatically by CI after each
+release — do not hand-edit it.
+
+## [3.2.0] - 2026-09-05
+
+### Added
+
+- Universal native Windows drop target (`IDropTarget`, Tauri `dragDropEnabled`
+  off): virtual files (`FileGroupDescriptor`), bitmaps (`CF_DIB`/`PNG`), web
+  images, HTML, URLs, and text snippets land in a dated drop folder with unique
+  timestamp+rand names.
+- Instant folder drops: folders store size 0 instead of recursive size walks,
+  so huge trees no longer stall the shelf.
+- Single batched `files_updated` emit per `add_files` batch.
+- In-house thumbnail engine: thumb-rs Windows `IShellItemImageFactory` backend
+  vendored into `app/src-tauri/src/thumbnail.rs` (fixed 256px, `thiserror`
+  `ThumbnailError`, regression tests).
+- OpenCode automation: auto PR reviews (`opencode-review.yml`, free
+  `muse-spark-1.3` model at `xhigh`) and on-demand `/oc` tasks
+  (`opencode.yml`), plus a `/resolve-threads` playbook.
+- Website Linear-style redesign: dark-only canvas (`#010102`), surface ladder
+  + hairline borders, lavender CTA (`#5e6ad2`), Inter type, 1280px container,
+  emoji-free Lucide feature icons, touch-aware demo.
+- README refresh with hero, features, download CTA, and FAQ.
+
+### Fixed
+
+- OLE/HDROP double-free, `CF_HTML` fragment UTF-8 boundary panics, unaligned
+  UTF-16 decoding UB, hostile DIB dimensions (`i32::MIN` height, unchecked
+  `w*h*4`), invisible 32bpp BI_RGB PNGs, `GetDIBits` misuse, unbounded image
+  downloads (25MB streamed cap), poisoned `FileList` mutex handling.
+
+### Removed
+
+- Unpinned `thumb-rs` git dependency and `thumb-rs` submodule (fully in-house
+  now); unused `active-win-pos-rs` dependency and macOS-only transitive deps
+  from Windows builds.
+
+## [3.1.0] - 2026-09-04
+
+- Windows OLE native drop target: files, web images, URLs, and text snippets.
+- Internationalization (i18n): 25 locales, browser-locale detection, RTL
+  layout, unlistener lifecycle cleanup.
+- Website: shared button system, SEO overhaul (sitemap, JSON-LD, OG/Twitter,
+  analytics), docs/pricing/changelog/`vs/*` comparison routes.
+
+## [3.0.0] - 2026-07-02
+
+- Major Windows release: floating file shelf, mouse-shake summon gesture,
+  global hotkey, browser-image drops, system-tray integration, auto-launch on
+  startup, macOS support groundwork.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "holdem",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "holdem",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "holdem",
   "private": true,
-  "version": "3.1.0",
+  "version": "3.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -1755,7 +1755,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holdem"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holdem"
-version = "3.1.0"
+version = "3.2.0"
 description = "A Tauri App"
 authors = ["Zubin"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "holdem",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "identifier": "com.holdem.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/holdem_website/app/changelog/page.tsx
+++ b/holdem_website/app/changelog/page.tsx
@@ -5,7 +5,7 @@ import { GITHUB_REPO } from '@/lib/constants'
 export const metadata: Metadata = {
   title: 'Changelog — Holdem Release Notes',
   description:
-    'Holdem changelog and release notes. Current release v3.1.0. Full version history on GitHub Releases.',
+    'Holdem changelog and release notes. Current release v3.2.0. Full version history on GitHub Releases.',
   alternates: {
     canonical: 'https://holdem.iamzub.in/changelog',
   },
@@ -51,10 +51,35 @@ export default function ChangelogPage() {
       <div className="mt-8 space-y-4">
         <div className="border-hairline bg-surface-1 rounded-xl border p-5">
           <div className="flex items-baseline justify-between gap-3">
-            <h2 className="text-xl font-bold">v3.1.0</h2>
+            <h2 className="text-xl font-bold">v3.2.0</h2>
             <span className="bg-success/15 text-success shrink-0 rounded-full px-3 py-1 text-xs font-medium">
               Latest
             </span>
+          </div>
+          <p className="text-ink-subtle mt-1 text-sm">
+            See GitHub Releases for the full notes.
+          </p>
+          <p className="text-ink-muted mt-2">
+            Universal native drop target (virtual files, bitmaps, web images,
+            HTML, URLs, and text snippets land in a dated drop folder — folder
+            drops are now instant), in-house thumbnail engine (thumb-rs backend
+            vendored in, unpinned git dependency removed), crash-hardening
+            across the OLE pipeline, and a Linear-style dark-canvas website
+            redesign with emoji-free features.
+          </p>
+          <a
+            href={`${GITHUB_REPO}/releases`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 inline-block text-sm underline"
+          >
+            View v3.2.0 on GitHub →
+          </a>
+        </div>
+
+        <div className="border-hairline bg-surface-1 rounded-xl border p-5">
+          <div className="flex items-baseline justify-between gap-3">
+            <h2 className="text-xl font-bold">v3.1.0</h2>
           </div>
           <p className="text-ink-subtle mt-1 text-sm">
             See GitHub Releases for the full notes.

--- a/holdem_website/app/download/page.tsx
+++ b/holdem_website/app/download/page.tsx
@@ -64,7 +64,7 @@ export default function DownloadPage() {
           <Download className="h-5 w-5" /> Download Holdem for Windows (x64)
         </ButtonLink>
         <p className="text-ink-subtle mt-3 text-xs">
-          Current release: v3.1.0 · Windows 10/11 x64 · .exe installer ·{' '}
+          Current release: v3.2.0 · Windows 10/11 x64 · .exe installer ·{' '}
           <a
             href={`${GITHUB_REPO}/releases`}
             target="_blank"

--- a/holdem_website/app/layout.tsx
+++ b/holdem_website/app/layout.tsx
@@ -108,10 +108,10 @@ export default async function RootLayout({
     operatingSystem: 'Windows 10, Windows 11',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
     isAccessibleForFree: true,
-    softwareVersion: '3.1.0',
+    softwareVersion: '3.2.0',
     url: 'https://holdem.iamzub.in',
     downloadUrl:
-      'https://github.com/iamzubin/holdem/releases/download/3.1.0/holdem_3.1.0_x64-setup.exe',
+      'https://github.com/iamzubin/holdem/releases/download/3.2.0/holdem_3.2.0_x64-setup.exe',
     sameAs: ['https://github.com/iamzubin/holdem'],
     description:
       'Free, open-source drag-and-drop file shelf for Windows. Shake your mouse while dragging to summon a floating holding area.',

--- a/holdem_website/app/page.tsx
+++ b/holdem_website/app/page.tsx
@@ -347,7 +347,7 @@ export default function Home() {
               )}
             </ButtonLink>
             <p className="text-ink-subtle text-xs">
-              Windows 10/11 x64 · v3.1.0 · Free &amp; open-source ·{' '}
+              Windows 10/11 x64 · v3.2.0 · Free &amp; open-source ·{' '}
               <a
                 href="https://github.com/iamzubin/holdem/releases"
                 target="_blank"

--- a/holdem_website/app/vs/droppoint/page.tsx
+++ b/holdem_website/app/vs/droppoint/page.tsx
@@ -46,7 +46,7 @@ export const metadata: Metadata = {
 const faqs = [
   {
     q: 'Is DropPoint still maintained?',
-    a: 'Sporadically: no new release since v1.2.1 (September 2022), though the default branch saw an August 2026 modernization (Electron 21→43, Node 22, CI). Day to day it still works, but the release cadence is slow. Holdem is under active development (v3.1.0).',
+    a: 'Sporadically: no new release since v1.2.1 (September 2022), though the default branch saw an August 2026 modernization (Electron 21→43, Node 22, CI). Day to day it still works, but the release cadence is slow. Holdem is under active development (see the changelog).',
   },
   {
     q: 'How do Holdem and DropPoint differ technically?',
@@ -111,7 +111,7 @@ export default function VsDroppointPage() {
           <strong>Verdict:</strong> Need one free shelf across Windows, Mac, and
           Linux right now? DropPoint still does the job. On Windows alone,
           Holdem wins on weight (Tauri/Rust vs Electron), trigger (shake vs
-          Shift+CapsLock), maintenance (v3.1.0 vs no release since 2022), and
+           Shift+CapsLock), maintenance (actively maintained vs no release since 2022), and
           extras like browser-image drops.
         </div>
 
@@ -184,7 +184,7 @@ export default function VsDroppointPage() {
               </tr>
               <tr>
                 <td className="px-4 py-3 font-medium">Maintenance</td>
-                <td className="px-4 py-3">Active — current release v3.1.0</td>
+                <td className="px-4 py-3">Active — frequent releases with auto-update</td>
                 <td className="px-4 py-3">
                   Slow — no release since v1.2.1 (Sep 2022); Aug 2026 branch
                   update
@@ -235,7 +235,7 @@ export default function VsDroppointPage() {
           in an app patched sporadically. That is not an attack: open-source
           maintainers move on, and the GPL code remains available for anyone to
           fork. But if you are choosing a shelf to rely on daily, an actively
-          developed app (Holdem v3.1.0, Tauri auto-updates via{' '}
+           developed app (Holdem, with Tauri auto-updates via{' '}
           <code>update.json</code>) is the safer bet — which is exactly why
           Holdem exists rather than as a DropPoint fork.
         </p>

--- a/holdem_website/lib/constants.ts
+++ b/holdem_website/lib/constants.ts
@@ -1,4 +1,4 @@
 export const WEBSITE_URL = 'https://holdem.iamzub.in'
 export const DOWNLOAD_URL_FALLBACK =
-  'https://github.com/iamzubin/holdem/releases/download/3.1.0/holdem_3.1.0_x64-setup.exe'
+  'https://github.com/iamzubin/holdem/releases/download/3.2.0/holdem_3.2.0_x64-setup.exe'
 export const GITHUB_REPO = 'https://github.com/iamzubin/holdem'


### PR DESCRIPTION
## Release v3.2.0

Preps the 3.2.0 release. After merge, push tag `3.2.0` (currently local) -- CI builds the signed installer, publishes the GitHub Release with notes from `CHANGELOG.md`, and syncs `update.json`.

### App (3.1.0 -> 3.2.0)

- Universal native Windows drop target (`IDropTarget`, Tauri `dragDropEnabled` off): virtual files (`FileGroupDescriptor`), bitmaps (`CF_DIB`/`PNG`), web images, HTML, URLs, and text snippets land in a dated drop folder with unique names
- Instant folder drops (size 0, no recursive walks); single batched `files_updated` emit
- In-house thumbnails: thumb-rs Windows backend vendored into `thumbnail.rs` (`thiserror`, regression tests); unpinned git dep removed
- Hardening: OLE double-free, UTF-8/UTF-16 safety, DIB bounds, 25MB streamed download cap, poisoned-mutex handling
- Removed `active-win-pos-rs` dep and `thumb-rs` submodule

### Website

- New `v3.2.0` changelog entry (3.1.0 demoted), download URLs + layout metadata bumped to 3.2.0
- Evergreen `vs/droppoint` copy (no more per-release version strings there)
- `update.json` intentionally untouched -- CI syncs it post-release

### Repo / CI

- New root `CHANGELOG.md` as the single source of truth for release notes
- Fixed `tauri.yml` tag filter: bare `3.x.y` tags never matched `v*`, so no tag push would have triggered a build; now matches `v*.*.*` and `[0-9]*.[0-9]*.[0-9]*`
- New `publish-notes` job writes the matching `CHANGELOG.md` section into the Release body
- `.gitignore` now covers `key.txt*` (signing-key backup was untracked but unignored; verified against `tauri.conf.json` pubkey, confirmed GH Secrets already hold it, local copy deleted)

### Verification

- [x] `tsc --noEmit` clean in `holdem_website`
- [x] Workflow YAML parses; tag filters + jobs verified
- [x] `CHANGELOG.md` section extraction verified (matches what `publish-notes` runs)
- [x] No stray `3.1.0` references outside history entries and CI-synced `update.json`

### Post-merge

    git checkout master; git pull
    git push origin 3.2.0

Then watch Actions: build -> signed assets -> notes -> `update.json` sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Updated the app and download listings to version 3.2.0.
  * Updated installer links and release metadata to point to the 3.2.0 build.

* **Documentation**
  * Added a changelog covering versions 3.0.0 through 3.2.0, including new features, fixes, and maintenance updates.
  * Updated the website’s changelog page with the 3.2.0 release and refreshed version descriptions across the homepage, download page, and comparison content.

* **Release Management**
  * Release notes are now automatically synchronized with the corresponding changelog section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->